### PR TITLE
 [#56 #57] Fix building on windows

### DIFF
--- a/atlas-core/src/main/java/io/atlasmap/core/AtlasUtil.java
+++ b/atlas-core/src/main/java/io/atlasmap/core/AtlasUtil.java
@@ -216,7 +216,7 @@ public class AtlasUtil {
     }
 
     public static List<Class<?>> findClassesForPackage(String scannedPackage) {
-        String scannedPath = scannedPackage.replace('.', File.separatorChar);
+        String scannedPath = scannedPackage.replace('.', '/');
         URL scannedUrl = getResource(scannedPath);
         
         if (scannedUrl == null) {

--- a/atlas-core/src/test/java/io/atlasmap/core/AtlasUtilTest.java
+++ b/atlas-core/src/test/java/io/atlasmap/core/AtlasUtilTest.java
@@ -104,9 +104,16 @@ public class AtlasUtilTest {
 	public void testFindClassesForPackage() {
 	    List<Class<?>> classes = AtlasUtil.findClassesForPackage("io.atlasmap.v2");
 	    assertNotNull(classes);
+	    int found = 0;
 	    for(Class<?> clazz : classes) {
-	        System.out.println("Class: " + clazz.getName());
+	        //System.out.println(clazz);
+	        if("io.atlasmap.v2.Field".equals(clazz.getName())) { found++; }
+	        if("io.atlasmap.v2.AtlasMapping".equals(clazz.getName())) { found++; }
+	        if("io.atlasmap.v2.Action".equals(clazz.getName())) { found++; }
+	        if("io.atlasmap.v2.Capitalize".equals(clazz.getName())) { found++; }
 	    }
+	    
+	    assertEquals(new Integer(4), new Integer(found));
 	}
 
 }

--- a/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/ClassInspectionServiceTest.java
+++ b/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/ClassInspectionServiceTest.java
@@ -109,9 +109,9 @@ public class ClassInspectionServiceTest {
 		String tmpcp = File.separator + "foo.jar:" + File.separator + "bar.jar:" + File.separator + "blah.jar";
 		assertNotNull(cis.classpathStringToList(tmpcp));
 		assertEquals(new Integer(3), new Integer(cis.classpathStringToList(tmpcp).size()));
-		assertEquals("/foo.jar", cis.classpathStringToList(tmpcp).get(0));
-		assertEquals("/bar.jar", cis.classpathStringToList(tmpcp).get(1));
-		assertEquals("/blah.jar", cis.classpathStringToList(tmpcp).get(2));
+		assertEquals(File.separator +"foo.jar", cis.classpathStringToList(tmpcp).get(0));
+		assertEquals(File.separator +"bar.jar", cis.classpathStringToList(tmpcp).get(1));
+		assertEquals(File.separator +"blah.jar", cis.classpathStringToList(tmpcp).get(2));
 	}
 
 }


### PR DESCRIPTION
  - Do not use File.Separator for java resource paths
  - Use File.Separator for a unit test