### PR TITLE
chore(build): Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,36 @@
+properties([
+  buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '5'))
+])
+
+podTemplate(
+  cloud: 'openshift',
+  label: 'atlasmap-ci',
+  containers: [
+    containerTemplate(
+      name: 'maven',
+      image: 'openjdk:8',
+      ttyEnabled: true,
+      command: 'cat',
+      envVars: [
+        containerEnvVar(key: 'HOME', value: '/home/jenkins')
+      ]
+    )
+  ],
+  volumes: [
+    secretVolume(secretName: 'm2-settings', mountPath: '/home/jenkins/.m2-ro')
+  ]
+)
+
+{
+  node('atlasmap-ci') {
+    stage('Build') {
+      checkout scm
+
+      container('maven') {
+        sh "./mvnw -Dmaven.test.failure.ignore=true -Duser.home=/home/jenkins -B -fae -s /home/jenkins/.m2-ro/settings.xml clean install"
+        junit '**/target/surefire-reports/TEST-*.xml'
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
This adds a Jenkinsfile using non-declarative pipeline syntax to perform
simple `./mvnw install` build and archive the unit test results.

`m2-settings` kubernetes secret is mounted in `.m2-ro` and `-s`
parameter is passed to the location of `settings.xml` contained within.