### PR TITLE
Add ${project.version} comment to the xsd files

### DIFF
--- a/atlas-java-parent/atlas-java-model/pom.xml
+++ b/atlas-java-parent/atlas-java-model/pom.xml
@@ -68,6 +68,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>

--- a/atlas-java-parent/atlas-java-model/src/main/resources/atlas-java-model-v2.xsd
+++ b/atlas-java-parent/atlas-java-model/src/main/resources/atlas-java-model-v2.xsd
@@ -6,6 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
+<!-- ${project.version} -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:atlas="http://atlasmap.io/v2"
     xmlns:atlasj="http://atlasmap.io/java/v2" targetNamespace="http://atlasmap.io/java/v2"
     elementFormDefault="qualified" attributeFormDefault="unqualified">

--- a/atlas-java-parent/atlas-java-model/src/main/resources/atlas-java-model-v2.xsd
+++ b/atlas-java-parent/atlas-java-model/src/main/resources/atlas-java-model-v2.xsd
@@ -6,7 +6,6 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<!-- ${project.version} -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:atlas="http://atlasmap.io/v2"
     xmlns:atlasj="http://atlasmap.io/java/v2" targetNamespace="http://atlasmap.io/java/v2"
     elementFormDefault="qualified" attributeFormDefault="unqualified">
@@ -177,3 +176,5 @@
     </simpleType>
 
 </schema>
+
+<!-- Atlasmap: ${project.version} -->

--- a/atlas-json-parent/atlas-json-model/pom.xml
+++ b/atlas-json-parent/atlas-json-model/pom.xml
@@ -70,6 +70,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>

--- a/atlas-json-parent/atlas-json-model/src/main/resources/atlas-json-model-v2.xsd
+++ b/atlas-json-parent/atlas-json-model/src/main/resources/atlas-json-model-v2.xsd
@@ -6,6 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
+<!-- ${project.version} -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:atlas="http://atlasmap.io/v2"
     xmlns:atlasjs="http://atlasmap.io/json/v2" targetNamespace="http://atlasmap.io/json/v2"
     elementFormDefault="qualified" attributeFormDefault="unqualified">

--- a/atlas-model/src/main/resources/atlas-model-v2.xsd
+++ b/atlas-model/src/main/resources/atlas-model-v2.xsd
@@ -6,6 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
+<!-- ${project.version} -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:atlas="http://atlasmap.io/v2"
     targetNamespace="http://atlasmap.io/v2" elementFormDefault="qualified"
     attributeFormDefault="unqualified">

--- a/atlas-model/src/main/resources/atlas-model-v2.xsd
+++ b/atlas-model/src/main/resources/atlas-model-v2.xsd
@@ -6,7 +6,6 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<!-- ${project.version} -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:atlas="http://atlasmap.io/v2"
     targetNamespace="http://atlasmap.io/v2" elementFormDefault="qualified"
     attributeFormDefault="unqualified">
@@ -419,3 +418,5 @@
     </complexType>
 
 </schema>
+
+<!-- Atlasmap: ${project.version} -->

--- a/atlas-xml-parent/atlas-xml-model/pom.xml
+++ b/atlas-xml-parent/atlas-xml-model/pom.xml
@@ -70,6 +70,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>

--- a/atlas-xml-parent/atlas-xml-model/src/main/resources/atlas-xml-model-v2.xsd
+++ b/atlas-xml-parent/atlas-xml-model/src/main/resources/atlas-xml-model-v2.xsd
@@ -16,6 +16,7 @@
     limitations under the License.
 
 -->
+<!-- ${project.version} -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:atlas="http://atlasmap.io/v2"
     xmlns:atlasx="http://atlasmap.io/xml/v2" targetNamespace="http://atlasmap.io/xml/v2"
     elementFormDefault="qualified" attributeFormDefault="unqualified">

--- a/atlas-xml-parent/atlas-xml-model/src/main/resources/atlas-xml-model-v2.xsd
+++ b/atlas-xml-parent/atlas-xml-model/src/main/resources/atlas-xml-model-v2.xsd
@@ -16,7 +16,6 @@
     limitations under the License.
 
 -->
-<!-- ${project.version} -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:atlas="http://atlasmap.io/v2"
     xmlns:atlasx="http://atlasmap.io/xml/v2" targetNamespace="http://atlasmap.io/xml/v2"
     elementFormDefault="qualified" attributeFormDefault="unqualified">
@@ -201,3 +200,5 @@
         </restriction>
     </simpleType>
 </schema>
+
+<!-- Atlasmap: ${project.version} -->

--- a/atlas-xml-parent/atlas-xml-test-model/pom.xml
+++ b/atlas-xml-parent/atlas-xml-test-model/pom.xml
@@ -57,6 +57,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>

--- a/atlas-xml-parent/atlas-xml-test-model/src/main/resources/atlas-xml-test-model-v2.xsd
+++ b/atlas-xml-parent/atlas-xml-test-model/src/main/resources/atlas-xml-test-model-v2.xsd
@@ -16,6 +16,7 @@
     limitations under the License.
 
 -->
+<!-- ${project.version} -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ns="http://atlasmap.io/xml/test/v2"
     targetNamespace="http://atlasmap.io/xml/test/v2" elementFormDefault="qualified"
     attributeFormDefault="unqualified">

--- a/atlas-xml-parent/atlas-xml-test-model/src/main/resources/atlas-xml-test-model-v2.xsd
+++ b/atlas-xml-parent/atlas-xml-test-model/src/main/resources/atlas-xml-test-model-v2.xsd
@@ -16,7 +16,6 @@
     limitations under the License.
 
 -->
-<!-- ${project.version} -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ns="http://atlasmap.io/xml/test/v2"
     targetNamespace="http://atlasmap.io/xml/test/v2" elementFormDefault="qualified"
     attributeFormDefault="unqualified">
@@ -165,3 +164,6 @@
         </restriction>
     </simpleType>
 </schema>
+
+<!-- Atlasmap: ${project.version} -->
+

--- a/atlas-xml-parent/atlas-xml-test-model/src/main/resources/atlas-xml-test-model-v2.xsd
+++ b/atlas-xml-parent/atlas-xml-test-model/src/main/resources/atlas-xml-test-model-v2.xsd
@@ -166,4 +166,3 @@
 </schema>
 
 <!-- Atlasmap: ${project.version} -->
-


### PR DESCRIPTION
Nexus staging rules are failing on atlasmap, complaining that the xsd files that are being deployed are the same as the ones from the previous build, and that they need to be unique.    I'm not sure why this happens for atlasmap, and not for other projects (camel, etc) that also use attach-artifacts to deploy an xsd, but my guess is that the different projects/repos have different sets of staging rules. 

We can get around this pretty easily by just sticking a comment with the project.version in the xsds.  If there's an a more standard way of inserting some sort of build identifier into an xsd or some other way of making them unique between builds, I'll definitely change this PR to use that instead.    My hope is to get whatever fix is best into upstream though and not insert patches into the build stream.