### PR TITLE
chore(dependency): upgrade Camel to newest Fuse EA

### DIFF
--- a/atlas-parent/pom.xml
+++ b/atlas-parent/pom.xml
@@ -35,7 +35,7 @@
         <!-- TODO syndesis connectors should be removed -->
         <syndesis.connector.version>0.5.5</syndesis.connector.version>
         <!-- TODO camel should be removed -->
-        <camel.version>2.20.0.fuse-000101</camel.version>
+        <camel.version>2.20.0.fuse-000106</camel.version>
 
         <asciidoctor-maven-plugin.version>1.5.5</asciidoctor-maven-plugin.version>
         <asciidoctorj.version>1.5.6</asciidoctorj.version>


### PR DESCRIPTION
This upgrades Camel to the newest version from Fuse early access builds.