### PR TITLE
refactor: upgrade Camel to 2.20.0

### DIFF
--- a/atlas-parent/pom.xml
+++ b/atlas-parent/pom.xml
@@ -35,7 +35,7 @@
         <!-- TODO syndesis connectors should be removed -->
         <syndesis.connector.version>0.5.5</syndesis.connector.version>
         <!-- TODO camel should be removed -->
-        <camel.version>2.20.0.fuse-000106</camel.version>
+        <camel.version>2.20.0</camel.version>
 
         <asciidoctor-maven-plugin.version>1.5.5</asciidoctor-maven-plugin.version>
         <asciidoctorj.version>1.5.6</asciidoctorj.version>
@@ -419,31 +419,6 @@
             </snapshots>
         </repository>
         <repository>
-            <id>fusesource.public</id>
-            <name>Fusesource Public Release Repositories</name>
-            <url>https://repository.jboss.org/nexus/content/groups/fs-public</url>
-            <layout>default</layout>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-        </repository>
-        <repository>
-            <id>fusesource.ea</id>
-            <name>Fusesource Early Access Release Repository</name>
-            <url>https://repository.jboss.org/nexus/content/groups/ea</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-        </repository>
-        <repository>
             <id>redhat-ga-repository</id>
             <url>https://maven.repository.redhat.com/ga</url>
             <releases>
@@ -470,31 +445,6 @@
         </repository>
     </repositories>
     <pluginRepositories>
-        <pluginRepository>
-            <id>fusesource.public</id>
-            <name>Fusesource Public Release Repositories</name>
-            <url>https://repository.jboss.org/nexus/content/groups/fs-public</url>
-            <layout>default</layout>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-        </pluginRepository>
-        <pluginRepository>
-            <id>fusesource.ea</id>
-            <name>Fusesource Early Access Release Repository</name>
-            <url>https://repository.jboss.org/nexus/content/groups/ea</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-        </pluginRepository>
         <pluginRepository>
             <id>redhat-ga-repository</id>
             <url>https://maven.repository.redhat.com/ga</url>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -251,25 +251,6 @@
 
     </dependencies>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>ipaas-releases</id>
-            <name>ipaas-releases</name>
-            <url>https://dl.bintray.com/redhat-ipaas/maven/</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>jboss.ea</id>
-            <name>JBoss EA</name>
-            <url>https://repository.jboss.org/nexus/content/groups/ea</url>
-        </repository>
-    </repositories>
-
     <profiles>
         <profile>
             <id>ci</id>


### PR DESCRIPTION
This upgrades Camel to 2.20.0 from Fuse EA, also removes Fuse EA repositories. Please check that I haven't overreached in repository removal.