### PR TITLE
 #216 Update DefaultFieldActionService to support overloaded FieldAction names

### DIFF
--- a/atlas-api/src/main/java/io/atlasmap/api/AtlasFieldActionService.java
+++ b/atlas-api/src/main/java/io/atlasmap/api/AtlasFieldActionService.java
@@ -17,6 +17,7 @@ package io.atlasmap.api;
 
 import io.atlasmap.v2.ActionDetail;
 import io.atlasmap.v2.Actions;
+import io.atlasmap.v2.Field;
 import io.atlasmap.v2.FieldType;
 
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.List;
 public interface AtlasFieldActionService {
 
     List<ActionDetail> listActionDetails();
+    void processActions(Actions actions, Field field) throws AtlasException;
+    Object processActions(Actions actions, Object sourceValue, FieldType targetType) throws AtlasException;
 
-    Object processActions(Actions actions, Object object, FieldType targetType) throws AtlasException;
 }

--- a/atlas-core/src/main/java/io/atlasmap/core/BaseAtlasModule.java
+++ b/atlas-core/src/main/java/io/atlasmap/core/BaseAtlasModule.java
@@ -424,7 +424,7 @@ public abstract class BaseAtlasModule implements AtlasModule {
     }
 
     protected void processFieldActions(AtlasFieldActionService fieldActionService, Field field) throws AtlasException {
-        field.setValue(fieldActionService.processActions(field.getActions(), field.getValue(), field.getFieldType()));
+        fieldActionService.processActions(field.getActions(), field);
     }
 
     @Override

--- a/atlas-core/src/main/java/io/atlasmap/core/DefaultAtlasFieldActionService.java
+++ b/atlas-core/src/main/java/io/atlasmap/core/DefaultAtlasFieldActionService.java
@@ -4,6 +4,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.ServiceLoader;
 
@@ -25,28 +27,27 @@ import io.atlasmap.v2.ActionDetail;
 
 public class DefaultAtlasFieldActionService implements AtlasFieldActionService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultAtlasFieldActionService.class);
+    private static final Logger logger = LoggerFactory.getLogger(DefaultAtlasFieldActionService.class);
     private ActionDetails actionDetails = new ActionDetails();
     private AtlasConversionService conversionService = null;
-
+    
     public DefaultAtlasFieldActionService(AtlasConversionService conversionService) {
         this.conversionService = conversionService;
     }
-
+    
     public void init() {
         loadFieldActions();
     }
 
     protected void loadFieldActions() {
         ClassLoader classLoader = this.getClass().getClassLoader();
-        final ServiceLoader<AtlasFieldAction> fieldActionServiceLoader = ServiceLoader.load(AtlasFieldAction.class,
-                classLoader);
+        final ServiceLoader<AtlasFieldAction> fieldActionServiceLoader = ServiceLoader.load(AtlasFieldAction.class, classLoader);
         for (final AtlasFieldAction atlasFieldAction : fieldActionServiceLoader) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Loading FieldAction class: " + atlasFieldAction.getClass().getCanonicalName());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Loading FieldAction class: " + atlasFieldAction.getClass().getCanonicalName());
             }
-
-            Class<?> clazz = atlasFieldAction.getClass();
+            
+            Class<?> clazz = atlasFieldAction.getClass();             
             Method[] methods = clazz.getMethods();
             for (Method method : methods) {
                 AtlasFieldActionInfo annotation = method.getAnnotation(AtlasFieldActionInfo.class);
@@ -63,164 +64,177 @@ public class DefaultAtlasFieldActionService implements AtlasFieldActionService {
                     try {
                         det.setParameters(detectFieldActionParameters("io.atlasmap.v2." + annotation.name()));
                     } catch (ClassNotFoundException e) {
-                        LOG.error(String.format("Error detecting parameters for field action=%s msg=%s",
-                                annotation.name(), e.getMessage()), e);
+                        logger.error(String.format("Error detecting parameters for field action=%s msg=%s", annotation.name(), e.getMessage()), e);
                     }
-
-                    if (LOG.isTraceEnabled()) {
-                        LOG.trace("Loaded FieldAction: " + det.getName());
+                    
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Loaded FieldAction: " + det.getName());
                     }
                     listActionDetails().add(det);
                 }
             }
         }
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(String.format("Loaded %s Field Actions", listActionDetails().size()));
+    
+        if (logger.isDebugEnabled()) {
+            logger.debug(String.format("Loaded %s Field Actions", listActionDetails().size()));
         }
     }
 
     @Override
-    public List<ActionDetail> listActionDetails() {
+	public List<ActionDetail> listActionDetails() {
         return actionDetails.getActionDetail();
     }
-
+    
+    /**
+     * TODO: getActionDetailByActionName() when all references are updated to use
+     * 
+     * ActionDetail = findActionDetail(String actionName, FieldType sourceType)
+     * 
+     * ref: https://github.com/atlasmap/atlasmap-runtime/issues/216
+     */
+    @Deprecated
     protected ActionDetail getActionDetailByActionName(String actionName) {
-        for (ActionDetail actionDetail : listActionDetails()) {
-            if (actionDetail.getName().equals(actionName)) {
+        for(ActionDetail actionDetail : listActionDetails()) {
+            if(actionDetail.getName().equals(actionName)) {
                 return actionDetail;
             }
         }
-
+        
         return null;
+    }
+    
+    /**
+     * 1. Find FieldAction by name
+     * 2. If multiple matches are found, return the best one based on FieldType sourceType
+     * 3. If there is not an exact match to sourceType, return the first FieldAction
+     * 4. If no matches found, return null
+     * 
+     * 
+     * @param actionName The name of the FieldAction
+     * @param sourceType A hint used to determine which FieldAction to use 
+     *                   when multiple FieldActions exist with the same name
+     *
+     * @return
+     */
+    protected ActionDetail findActionDetail(String actionName, FieldType sourceType) {
+        
+        List<ActionDetail> matches = new ArrayList<ActionDetail>();
+        for(ActionDetail actionDetail : listActionDetails()) {
+            if(actionDetail.getName().equals(actionName)) {
+                matches.add(actionDetail);
+            }
+        }
+        
+        switch(matches.size()) {
+        case 0: return null;
+        case 1: return matches.get(0);
+        default:
+            if(sourceType != null && !Arrays.asList(FieldType.ALL, FieldType.NONE).contains(sourceType)) {
+                for(ActionDetail actionDetail : matches) {
+                    if(sourceType.equals(actionDetail.getSourceType())) {
+                        return actionDetail;
+                    }
+                }
+            }
+            return matches.get(0);   
+        }
     }
 
     @Override
     public Object processActions(Actions actions, Object sourceObject, FieldType targetType) throws AtlasException {
 
-        if (FieldType.COMPLEX.equals(targetType)) {
+        if(FieldType.COMPLEX.equals(targetType)) {
             return sourceObject;
         }
-
+         
         Object targetObject = null;
         Object tmpSourceObject = sourceObject;
-        FieldType sourceType = (sourceObject != null
-                ? getConversionService().fieldTypeFromClass(sourceObject.getClass())
-                : FieldType.NONE);
-
-        if (actions == null || actions.getActions() == null || actions.getActions().isEmpty()) {
-            if (sourceObject == null) {
+        FieldType sourceType = (sourceObject != null ? getConversionService().fieldTypeFromClass(sourceObject.getClass()) : FieldType.NONE);
+        
+        if(actions == null || actions.getActions() == null || actions.getActions().isEmpty()) {
+            if(sourceObject == null) {
                 return null;
             }
             return getConversionService().convertType(sourceObject, sourceType, targetType);
         }
-
+        
         FieldType currentType = sourceType;
-        for (Action action : actions.getActions()) {
-            ActionDetail detail = getActionDetailByActionName(action.getClass().getSimpleName());
-            if (!detail.getSourceType().equals(currentType) && !FieldType.ALL.equals(detail.getSourceType())) {
+        for(Action action : actions.getActions()) {
+            ActionDetail detail = findActionDetail(action.getClass().getSimpleName(), currentType);
+            if(!detail.getSourceType().equals(currentType) && !FieldType.ALL.equals(detail.getSourceType())) {
                 tmpSourceObject = getConversionService().convertType(sourceObject, currentType, detail.getSourceType());
             }
-
-            targetObject = processAction(action, getActionDetailByActionName(action.getClass().getSimpleName()),
-                    tmpSourceObject);
+            
+            targetObject = processAction(action, detail, tmpSourceObject);
             currentType = detail.getTargetType();
         }
-
-        if (currentType != null && !currentType.equals(targetType)) {
+        
+        if(currentType != null && !currentType.equals(targetType)) {
             targetObject = getConversionService().convertType(targetObject, currentType, targetType);
         }
-
+        
         return targetObject;
     }
-
-    protected Object processAction(Action action, ActionDetail actionDetail, Object sourceObject)
-            throws AtlasException {
+    
+    protected Object processAction(Action action, ActionDetail actionDetail, Object sourceObject) throws AtlasException {
         Object targetObject = null;
-        if (actionDetail != null) {
+        if(actionDetail != null) {
             Object actionObject = null;
             try {
                 Class<?> actionClazz = Class.forName(actionDetail.getClassName());
                 actionObject = actionClazz.newInstance();
-
-                Method method = null;
-                if (actionDetail.getSourceType() != null) {
-                    switch (actionDetail.getSourceType()) {
-                    case BOOLEAN:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Boolean.class);
-                        break;
-                    case BYTE:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Byte.class);
-                        break;
-                    case BYTE_ARRAY:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Byte[].class);
-                        break;
-                    case CHAR:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Character.class);
-                        break;
-                    case DOUBLE:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Double.class);
-                        break;
-                    case FLOAT:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Float.class);
-                        break;
-                    case INTEGER:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Integer.class);
-                        break;
-                    case LONG:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Long.class);
-                        break;
-                    case SHORT:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Short.class);
-                        break;
-                    case STRING:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, String.class);
-                        break;
-                    case ALL:
-                        method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Object.class);
-                        break;
-                    default:
-                        LOG.warn(String.format("Unsupported sourceType=%s in actionClass=%s",
-                                actionDetail.getSourceType().value(), actionDetail.getClassName()));
+                
+                Method method =  null;
+                if(actionDetail.getSourceType() != null) {
+                    switch(actionDetail.getSourceType()) {
+                    case BOOLEAN: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Boolean.class); break;
+                    case BYTE: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Byte.class); break;
+                    case BYTE_ARRAY: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Byte[].class); break;
+                    case CHAR: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Character.class); break;
+                    case DOUBLE: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Double.class); break;
+                    case FLOAT: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Float.class); break;
+                    case INTEGER: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Integer.class); break;
+                    case LONG: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Long.class); break;
+                    case SHORT: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Short.class); break;
+                    case STRING: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, String.class); break;
+                    case ALL: method = actionClazz.getMethod(actionDetail.getMethod(), Action.class, Object.class); break;
+                    default: 
+                        logger.warn(String.format("Unsupported sourceType=%s in actionClass=%s", actionDetail.getSourceType().value(), actionDetail.getClassName()));
                         break;
                     }
                 }
-
-                if (method == null) {
-                    throw new AtlasException(
-                            String.format("Unable to locate field action className=%s method=%s sourceType=%s",
-                                    actionDetail.getClassName(), actionDetail.getMethod(),
-                                    actionDetail.getSourceType().value()));
+                
+                if(method == null) {
+                    throw new AtlasException(String.format("Unable to locate field action className=%s method=%s sourceType=%s", actionDetail.getClassName(), actionDetail.getMethod(), actionDetail.getSourceType().value()));
                 }
-
-                if (Modifier.isStatic(method.getModifiers())) {
+               
+                if(Modifier.isStatic(method.getModifiers())) {
                     targetObject = method.invoke(null, action, sourceObject);
                 } else {
                     targetObject = method.invoke(actionObject, action, sourceObject);
                 }
-            } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | SecurityException
-                    | ClassNotFoundException | IllegalArgumentException | InvocationTargetException e) {
+            } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | SecurityException | ClassNotFoundException | IllegalArgumentException | InvocationTargetException e) {
                 throw new AtlasException(String.format("Error processing action %s", actionDetail.getName()), e);
             }
             return targetObject;
         }
         return sourceObject;
     }
-
+    
     protected Properties detectFieldActionParameters(String actionClassName) throws ClassNotFoundException {
         Class<?> actionClazz = Class.forName(actionClassName);
-
+        
         Properties props = null;
-        for (Method method : actionClazz.getMethods()) {
+        for(Method method : actionClazz.getMethods()) {
             // Find setters to avoid the get / is confusion
-            if (method.getParameterCount() == 1 && method.getName().startsWith("set")) {
+            if(method.getParameterCount() == 1 && method.getName().startsWith("set")) {
                 // We have a parameter
-                if (props == null) {
+                if(props == null) {
                     props = new Properties();
                 }
-
+                
                 Property prop = null;
-                for (Parameter param : method.getParameters()) {
+                for(Parameter param : method.getParameters()) {
                     prop = new Property();
                     prop.setName(camelize(method.getName().substring("set".length())));
                     prop.setFieldType(getConversionService().fieldTypeFromClass(param.getType()));
@@ -228,14 +242,14 @@ public class DefaultAtlasFieldActionService implements AtlasFieldActionService {
                 }
             }
         }
-
+        
         return props;
     }
-
+    
     public AtlasConversionService getConversionService() {
         return this.conversionService;
     }
-
+    
     public static String camelize(String parameter) {
         if (parameter == null || parameter.length() == 0) {
             return parameter;

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/pom.xml
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2017 Red Hat, Inc. Licensed under the Apache License, 
+  Version 2.0 (the "License"); you may not use this file except in compliance 
+  with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+  Unless required by applicable law or agreed to in writing, software distributed 
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+  OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+  the specific language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.atlasmap</groupId>
+    <artifactId>atlas-itests-parent</artifactId>
+    <version>1.31-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>atlas-itests-mock-fieldactions</artifactId>
+  <packaging>bundle</packaging>
+  <name>Atlas :: iTests Mock Field Actions</name>
+
+  <properties>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.atlasmap</groupId>
+      <artifactId>atlas-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.atlasmap</groupId>
+      <artifactId>atlas-core</artifactId>
+    </dependency>
+    <dependency>
+       <groupId>io.atlasmap</groupId>
+       <artifactId>atlas-java-test-model</artifactId>
+       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+       <groupId>io.atlasmap</groupId>
+       <artifactId>atlas-java-module</artifactId>
+       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+ </project>
+   

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DateTimeFieldActions.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DateTimeFieldActions.java
@@ -33,9 +33,8 @@ public class DateTimeFieldActions implements AtlasFieldAction {
         case 5: return "Thursday";
         case 6: return "Friday";
         case 7: return "Saturday";
+        default: return "Funday";
         }
-        
-        return "Funday";
     }
     
     @AtlasFieldActionInfo(name = "DayOfWeek", sourceType = FieldType.STRING, targetType = FieldType.STRING, sourceCollectionType = CollectionType.NONE, targetCollectionType = CollectionType.NONE)

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DateTimeFieldActions.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DateTimeFieldActions.java
@@ -47,9 +47,7 @@ public class DateTimeFieldActions implements AtlasFieldAction {
         case "thur": return "Thursday";
         case "fri": return "Friday";
         case "sat": return "Saturday";
+        default: return "Funday";
         }
-        
-        return "Funday";
-
     }
 }

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DateTimeFieldActions.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DateTimeFieldActions.java
@@ -24,7 +24,7 @@ import io.atlasmap.v2.FieldType;
 public class DateTimeFieldActions implements AtlasFieldAction {
     
     @AtlasFieldActionInfo(name = "DayOfWeek", sourceType = FieldType.INTEGER, targetType = FieldType.STRING, sourceCollectionType = CollectionType.NONE, targetCollectionType = CollectionType.NONE)
-    public static String DayOfWeekInteger(Action action, Integer input) {
+    public static String dayOfWeekInteger(Action action, Integer input) {
         switch(input) {
         case 1: return "Sunday";
         case 2: return "Monday";
@@ -38,7 +38,7 @@ public class DateTimeFieldActions implements AtlasFieldAction {
     }
     
     @AtlasFieldActionInfo(name = "DayOfWeek", sourceType = FieldType.STRING, targetType = FieldType.STRING, sourceCollectionType = CollectionType.NONE, targetCollectionType = CollectionType.NONE)
-    public static String DayOfWeekString(Action action, String input) {
+    public static String dayOfWeekString(Action action, String input) {
         switch(input) {
         case "sun": return "Sunday";
         case "mon": return "Monday";

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DateTimeFieldActions.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DateTimeFieldActions.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.mock.v2;
+
+import io.atlasmap.api.AtlasFieldAction;
+import io.atlasmap.spi.AtlasFieldActionInfo;
+import io.atlasmap.v2.Action;
+import io.atlasmap.v2.CollectionType;
+import io.atlasmap.v2.FieldType;
+
+public class DateTimeFieldActions implements AtlasFieldAction {
+    
+    @AtlasFieldActionInfo(name = "DayOfWeek", sourceType = FieldType.INTEGER, targetType = FieldType.STRING, sourceCollectionType = CollectionType.NONE, targetCollectionType = CollectionType.NONE)
+    public static String DayOfWeekInteger(Action action, Integer input) {
+        switch(input) {
+        case 1: return "Sunday";
+        case 2: return "Monday";
+        case 3: return "Tuesday";
+        case 4: return "Wednesday";
+        case 5: return "Thursday";
+        case 6: return "Friday";
+        case 7: return "Saturday";
+        }
+        
+        return "Funday";
+    }
+    
+    @AtlasFieldActionInfo(name = "DayOfWeek", sourceType = FieldType.STRING, targetType = FieldType.STRING, sourceCollectionType = CollectionType.NONE, targetCollectionType = CollectionType.NONE)
+    public static String DayOfWeekString(Action action, String input) {
+        switch(input) {
+        case "sun": return "Sunday";
+        case "mon": return "Monday";
+        case "tue": return "Tuesday";
+        case "wed": return "Wednesday";
+        case "thur": return "Thursday";
+        case "fri": return "Friday";
+        case "sat": return "Saturday";
+        }
+        
+        return "Funday";
+
+    }
+}

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DayOfWeekInteger.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DayOfWeekInteger.java
@@ -1,0 +1,27 @@
+package io.atlasmap.mock.v2;
+
+import io.atlasmap.spi.AtlasFieldActionInfo;
+import io.atlasmap.v2.Action;
+import io.atlasmap.v2.CollectionType;
+import io.atlasmap.v2.FieldType;
+
+@AtlasFieldActionInfo(name = "DayOfWeek", sourceType = FieldType.INTEGER, targetType = FieldType.STRING, sourceCollectionType = CollectionType.NONE, targetCollectionType = CollectionType.NONE)
+public class DayOfWeekInteger extends Action {
+
+    private static final long serialVersionUID = 6401903284974777325L;
+
+    private Integer integerValue;
+
+    public Integer getIntegerValue() {
+        return integerValue;
+    }
+
+    public void setIntegerValue(Integer integerValue) {
+        this.integerValue = integerValue;
+    }
+   
+    @Override
+    public String getDisplayName() {
+        return "DayOfWeek";
+    }
+}

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DayOfWeekString.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/java/io/atlasmap/mock/v2/DayOfWeekString.java
@@ -1,0 +1,24 @@
+package io.atlasmap.mock.v2;
+
+import io.atlasmap.v2.Action;
+
+public class DayOfWeekString extends Action {
+
+    private static final long serialVersionUID = 6401903284974777325L;
+
+    private String stringValue;
+
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+    
+    @Override
+    public String getDisplayName() {
+        return "DayOfWeek";
+    }
+   
+}

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/resources/META-INF/services/io.atlasmap.api.AtlasFieldAction
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/main/resources/META-INF/services/io.atlasmap.api.AtlasFieldAction
@@ -1,0 +1,1 @@
+io.atlasmap.mock.v2.DateTimeFieldActions

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/test/java/io/atlasmap/mock/v2/DateTimeFieldActionsTest.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/test/java/io/atlasmap/mock/v2/DateTimeFieldActionsTest.java
@@ -1,40 +1,33 @@
 package io.atlasmap.mock.v2;
 
 import static org.junit.Assert.*;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class DateTimeFieldActionsTest {
-
-    private DateTimeFieldActions actions;
-    
-
     
     @Test
     public void testDayOfWeekActionInteger() {
-        assertEquals("Sunday", DateTimeFieldActions.DayOfWeekInteger(null, 1));
-        assertEquals("Monday", DateTimeFieldActions.DayOfWeekInteger(null, 2));
-        assertEquals("Tuesday", DateTimeFieldActions.DayOfWeekInteger(null, 3));
-        assertEquals("Wednesday", DateTimeFieldActions.DayOfWeekInteger(null, 4));
-        assertEquals("Thursday", DateTimeFieldActions.DayOfWeekInteger(null, 5));
-        assertEquals("Friday", DateTimeFieldActions.DayOfWeekInteger(null, 6));
-        assertEquals("Saturday", DateTimeFieldActions.DayOfWeekInteger(null, 7));
-        assertEquals("Funday", DateTimeFieldActions.DayOfWeekInteger(null, Integer.MIN_VALUE));
-        assertEquals("Funday", DateTimeFieldActions.DayOfWeekInteger(null, Integer.MAX_VALUE));
+        assertEquals("Sunday", DateTimeFieldActions.dayOfWeekInteger(null, 1));
+        assertEquals("Monday", DateTimeFieldActions.dayOfWeekInteger(null, 2));
+        assertEquals("Tuesday", DateTimeFieldActions.dayOfWeekInteger(null, 3));
+        assertEquals("Wednesday", DateTimeFieldActions.dayOfWeekInteger(null, 4));
+        assertEquals("Thursday", DateTimeFieldActions.dayOfWeekInteger(null, 5));
+        assertEquals("Friday", DateTimeFieldActions.dayOfWeekInteger(null, 6));
+        assertEquals("Saturday", DateTimeFieldActions.dayOfWeekInteger(null, 7));
+        assertEquals("Funday", DateTimeFieldActions.dayOfWeekInteger(null, Integer.MIN_VALUE));
+        assertEquals("Funday", DateTimeFieldActions.dayOfWeekInteger(null, Integer.MAX_VALUE));
     }
 
     @Test
     public void testDayOfWeekActionString() {
-        assertEquals("Sunday", DateTimeFieldActions.DayOfWeekString(null, "sun"));
-        assertEquals("Monday", DateTimeFieldActions.DayOfWeekString(null, "mon"));
-        assertEquals("Tuesday", DateTimeFieldActions.DayOfWeekString(null, "tue"));
-        assertEquals("Wednesday", DateTimeFieldActions.DayOfWeekString(null, "wed"));
-        assertEquals("Thursday", DateTimeFieldActions.DayOfWeekString(null, "thur"));
-        assertEquals("Friday", DateTimeFieldActions.DayOfWeekString(null, "fri"));
-        assertEquals("Saturday", DateTimeFieldActions.DayOfWeekString(null, "sat"));
-        assertEquals("Funday", DateTimeFieldActions.DayOfWeekString(null, "foobar"));    
+        assertEquals("Sunday", DateTimeFieldActions.dayOfWeekString(null, "sun"));
+        assertEquals("Monday", DateTimeFieldActions.dayOfWeekString(null, "mon"));
+        assertEquals("Tuesday", DateTimeFieldActions.dayOfWeekString(null, "tue"));
+        assertEquals("Wednesday", DateTimeFieldActions.dayOfWeekString(null, "wed"));
+        assertEquals("Thursday", DateTimeFieldActions.dayOfWeekString(null, "thur"));
+        assertEquals("Friday", DateTimeFieldActions.dayOfWeekString(null, "fri"));
+        assertEquals("Saturday", DateTimeFieldActions.dayOfWeekString(null, "sat"));
+        assertEquals("Funday", DateTimeFieldActions.dayOfWeekString(null, "foobar"));    
     }
 
 }

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/test/java/io/atlasmap/mock/v2/DateTimeFieldActionsTest.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/test/java/io/atlasmap/mock/v2/DateTimeFieldActionsTest.java
@@ -1,0 +1,29 @@
+package io.atlasmap.mock.v2;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DateTimeFieldActionsTest {
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testDayOfWeekActionInteger() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testDayOfWeekActionString() {
+        fail("Not yet implemented");
+    }
+
+}

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/test/java/io/atlasmap/mock/v2/DateTimeFieldActionsTest.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/test/java/io/atlasmap/mock/v2/DateTimeFieldActionsTest.java
@@ -8,14 +8,6 @@ import org.junit.Test;
 
 public class DateTimeFieldActionsTest {
 
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
-
     @Test
     public void testDayOfWeekActionInteger() {
         fail("Not yet implemented");

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/test/java/io/atlasmap/mock/v2/DateTimeFieldActionsTest.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/test/java/io/atlasmap/mock/v2/DateTimeFieldActionsTest.java
@@ -8,14 +8,33 @@ import org.junit.Test;
 
 public class DateTimeFieldActionsTest {
 
+    private DateTimeFieldActions actions;
+    
+
+    
     @Test
     public void testDayOfWeekActionInteger() {
-        fail("Not yet implemented");
+        assertEquals("Sunday", DateTimeFieldActions.DayOfWeekInteger(null, 1));
+        assertEquals("Monday", DateTimeFieldActions.DayOfWeekInteger(null, 2));
+        assertEquals("Tuesday", DateTimeFieldActions.DayOfWeekInteger(null, 3));
+        assertEquals("Wednesday", DateTimeFieldActions.DayOfWeekInteger(null, 4));
+        assertEquals("Thursday", DateTimeFieldActions.DayOfWeekInteger(null, 5));
+        assertEquals("Friday", DateTimeFieldActions.DayOfWeekInteger(null, 6));
+        assertEquals("Saturday", DateTimeFieldActions.DayOfWeekInteger(null, 7));
+        assertEquals("Funday", DateTimeFieldActions.DayOfWeekInteger(null, Integer.MIN_VALUE));
+        assertEquals("Funday", DateTimeFieldActions.DayOfWeekInteger(null, Integer.MAX_VALUE));
     }
 
     @Test
     public void testDayOfWeekActionString() {
-        fail("Not yet implemented");
+        assertEquals("Sunday", DateTimeFieldActions.DayOfWeekString(null, "sun"));
+        assertEquals("Monday", DateTimeFieldActions.DayOfWeekString(null, "mon"));
+        assertEquals("Tuesday", DateTimeFieldActions.DayOfWeekString(null, "tue"));
+        assertEquals("Wednesday", DateTimeFieldActions.DayOfWeekString(null, "wed"));
+        assertEquals("Thursday", DateTimeFieldActions.DayOfWeekString(null, "thur"));
+        assertEquals("Friday", DateTimeFieldActions.DayOfWeekString(null, "fri"));
+        assertEquals("Saturday", DateTimeFieldActions.DayOfWeekString(null, "sat"));
+        assertEquals("Funday", DateTimeFieldActions.DayOfWeekString(null, "foobar"));    
     }
 
 }

--- a/atlas-itests-parent/atlas-itests-mock-fieldactions/src/test/java/io/atlasmap/mock/v2/OverloadedFieldActionsTest.java
+++ b/atlas-itests-parent/atlas-itests-mock-fieldactions/src/test/java/io/atlasmap/mock/v2/OverloadedFieldActionsTest.java
@@ -1,0 +1,121 @@
+package io.atlasmap.mock.v2;
+
+import static org.junit.Assert.*;
+import java.util.List;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import io.atlasmap.api.AtlasContext;
+import io.atlasmap.api.AtlasSession;
+import io.atlasmap.core.DefaultAtlasContextFactory;
+import io.atlasmap.java.test.SourceFlatPrimitiveClass;
+import io.atlasmap.java.test.TargetFlatPrimitiveClass;
+import io.atlasmap.java.v2.JavaField;
+import io.atlasmap.v2.ActionDetail;
+import io.atlasmap.v2.Actions;
+import io.atlasmap.v2.AtlasMapping;
+import io.atlasmap.v2.AtlasModelFactory;
+import io.atlasmap.v2.DataSource;
+import io.atlasmap.v2.DataSourceType;
+import io.atlasmap.v2.Mapping;
+import io.atlasmap.v2.MappingType;
+import io.atlasmap.v2.Mappings;
+
+public class OverloadedFieldActionsTest {
+    
+    private static DefaultAtlasContextFactory atlasContextFactory = null;
+    
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        atlasContextFactory = DefaultAtlasContextFactory.getInstance();
+    }
+    
+    @Test
+    public void testListActions() throws Exception {
+        List<ActionDetail> actions = DefaultAtlasContextFactory.getInstance().getFieldActionService().listActionDetails();
+        
+        Integer found = 0;
+        for (ActionDetail d : actions) {
+            if(d.getName().equals("DayOfWeek")) {
+                found++;
+            }
+        }
+        assertEquals(Integer.valueOf(2), found);
+    }
+    
+    @Test
+    public void testMappingDayOfWeekString() throws Exception {
+        
+        AtlasContext context = atlasContextFactory.createContext(generateMappingDayOfWeek(String.class));
+        AtlasSession session = context.createSession();
+        SourceFlatPrimitiveClass src = new SourceFlatPrimitiveClass();
+        src.setBoxedStringField("mon");
+        session.setInput(src);
+        
+        context.process(session);
+        
+        Object tgt = session.getOutput();
+        assertNotNull(tgt);
+        assertTrue(tgt.getClass().isAssignableFrom(TargetFlatPrimitiveClass.class));
+        
+        System.out.println(((TargetFlatPrimitiveClass)tgt).getBoxedStringField());
+    }
+
+    @Test
+    public void testMappingDayOfWeekInteger() throws Exception {
+        AtlasContext context = atlasContextFactory.createContext(generateMappingDayOfWeek(Integer.class));
+        AtlasSession session = context.createSession();
+        SourceFlatPrimitiveClass src = new SourceFlatPrimitiveClass();
+        src.setIntField(1);
+        session.setInput(src);
+        
+        context.process(session);
+        
+        Object tgt = session.getOutput();
+        assertNotNull(tgt);
+        assertTrue(tgt.getClass().isAssignableFrom(TargetFlatPrimitiveClass.class));
+        
+        System.out.println(((TargetFlatPrimitiveClass)tgt).getBoxedStringField());
+    }
+    
+    protected AtlasMapping generateMappingDayOfWeek(Class<?> clazz) {
+        AtlasMapping m = new AtlasMapping();
+        DataSource s = new DataSource();
+        s.setDataSourceType(DataSourceType.SOURCE);
+        s.setUri("atlas:java?className=io.atlasmap.java.test.SourceFlatPrimitiveClass");
+        DataSource t = new DataSource();
+        t.setDataSourceType(DataSourceType.TARGET);
+        t.setUri("atlas:java?className=io.atlasmap.java.test.TargetFlatPrimitiveClass");
+        
+        m.getDataSource().add(s);
+        m.getDataSource().add(t);
+        
+        
+        Mapping mfm = AtlasModelFactory.createMapping(MappingType.MAP);
+        JavaField srcF = new JavaField();
+        Actions acts = new Actions();
+        srcF.setActions(acts);
+
+        JavaField tgtF = new JavaField();
+        
+        if(clazz.isAssignableFrom(String.class)) {
+            srcF.setPath("boxedStringField");
+            srcF.getActions().getActions().add(new DayOfWeekString());
+            tgtF.setPath("boxedStringField");
+
+        } else if(clazz.isAssignableFrom(Integer.class)){
+            srcF.setPath("intField");
+            srcF.getActions().getActions().add(new DayOfWeekInteger());
+            tgtF.setPath("boxedStringField");
+        }
+        
+        mfm.getInputField().add(srcF);
+        mfm.getOutputField().add(tgtF);
+        
+        Mappings maps = new Mappings();
+        maps.getMapping().add(mfm);
+        
+        m.setMappings(maps);
+        
+        return m;
+    }
+}

--- a/atlas-itests-parent/atlas-itests-reference-mappings/src/test/java/io/atlasmap/reference/AtlasBaseActionsTest.java
+++ b/atlas-itests-parent/atlas-itests-reference-mappings/src/test/java/io/atlasmap/reference/AtlasBaseActionsTest.java
@@ -59,65 +59,64 @@ public abstract class AtlasBaseActionsTest extends AtlasMappingBaseTest {
             System.out.println(d.getName());
         }
 
-        this.runActionTest(new Uppercase(), "fname", "FNAME");
-        this.runActionTest(new Lowercase(), "fnAme", "fname");
+        this.runActionTest(new Uppercase(), "fname", "FNAME", String.class);
+        this.runActionTest(new Lowercase(), "fnAme", "fname", String.class);
 
-        this.runActionTest(new Trim(), " fname ", "fname");
-        this.runActionTest(new TrimLeft(), " fname ", "fname ");
-        this.runActionTest(new TrimRight(), " fname ", " fname");
-        this.runActionTest(new Capitalize(), "fname", "Fname");
-        this.runActionTest(new SeparateByDash(), "f:name", "f-name");
-        this.runActionTest(new SeparateByUnderscore(), "f-na_me", "f_na_me");
+        this.runActionTest(new Trim(), " fname ", "fname", String.class);
+        this.runActionTest(new TrimLeft(), " fname ", "fname ", String.class);
+        this.runActionTest(new TrimRight(), " fname ", " fname", String.class);
+        this.runActionTest(new Capitalize(), "fname", "Fname", String.class);
+        this.runActionTest(new SeparateByDash(), "f:name", "f-name", String.class);
+        this.runActionTest(new SeparateByUnderscore(), "f-na_me", "f_na_me", String.class);
 
         SubString s = new SubString();
         s.setStartIndex(0);
         s.setEndIndex(3);
-        this.runActionTest(s, "12345", "123");
+        this.runActionTest(s, "12345", "123", String.class);
 
         SubStringAfter s1 = new SubStringAfter();
         s1.setStartIndex(3);
         s1.setEndIndex(null);
         s1.setMatch("foo");
-        this.runActionTest(s1, "foobarblah", "blah");
+        this.runActionTest(s1, "foobarblah", "blah", String.class);
 
         SubStringBefore s2 = new SubStringBefore();
         s2.setStartIndex(3);
         s2.setEndIndex(null);
         s2.setMatch("blah");
-        this.runActionTest(s2, "foobarblah", "bar");
+        this.runActionTest(s2, "foobarblah", "bar", String.class);
 
         PadStringRight ps = new PadStringRight();
         ps.setPadCharacter("X");
         ps.setPadCount(5);
-        this.runActionTest(ps, "fname", "fnameXXXXX");
+        this.runActionTest(ps, "fname", "fnameXXXXX", String.class);
 
         PadStringLeft pl = new PadStringLeft();
         pl.setPadCharacter("X");
         pl.setPadCount(5);
-        this.runActionTest(pl, "fname", "XXXXXfname");
+        this.runActionTest(pl, "fname", "XXXXXfname", String.class);
 
-        String result = (String) runActionTest(new CurrentDate(), "fname", null);
+        String result = (String) runActionTest(new CurrentDate(), "fname", null, String.class);
         assertTrue(Pattern.compile("20([1-9][0-9])-(0[0-9]|1[0-2])-(0[0-9]|1[0-9]|2[0-9]|3[0-1])").matcher(result)
                 .matches());
 
-        result = (String) runActionTest(new CurrentTime(), "fname", null);
+        result = (String) runActionTest(new CurrentTime(), "fname", null, String.class);
         assertTrue(Pattern.compile("([01]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]").matcher(result).matches());
 
-        result = (String) runActionTest(new CurrentDateTime(), "fname", null);
+        result = (String) runActionTest(new CurrentDateTime(), "fname", null, String.class);
         assertTrue(Pattern.compile("20([1-9][0-9])-(0[0-9]|1[0-2])-(0[0-9]|1[0-9]|2[0-9]|3[0-1])T[0-9]{2}:[0-9]{2}Z")
                 .matcher(result).matches());
 
-        result = (String) runActionTest(new GenerateUUID(), "fname", null);
+        result = (String) runActionTest(new GenerateUUID(), "fname", null, String.class);
         assertTrue(Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}").matcher(result)
                 .matches());
     }
 
-    public Object runActionTest(Action action, String inputFirstName, Object outputExpected) throws Exception {
-        return this.runActionTestList(Arrays.asList(action), inputFirstName, outputExpected);
+    public Object runActionTest(Action action, String inputFirstName, Object outputExpected, Class<?> ouputClassExpected) throws Exception {
+        return this.runActionTestList(Arrays.asList(action), inputFirstName, outputExpected, ouputClassExpected);
     }
 
-    public Object runActionTestList(List<Action> actions, String inputFirstName, Object outputExpected)
-            throws Exception {
+    public Object runActionTestList(List<Action> actions, String inputFirstName, Object outputExpected, Class<?> outputClassExpected) throws Exception {
         System.out.println("Now running test for actions: " + actions);
         System.out.println("Input: " + inputFirstName);
         System.out.println("Expected output: " + outputExpected);
@@ -157,7 +156,7 @@ public abstract class AtlasBaseActionsTest extends AtlasMappingBaseTest {
 
         Object outputActual = session.getOutput();
         assertNotNull(outputActual);
-        outputActual = getOutputValue(outputActual);
+        outputActual = getOutputValue(outputActual, outputClassExpected);
         if (outputExpected != null) {
             assertEquals(outputExpected, outputActual);
         }
@@ -167,10 +166,10 @@ public abstract class AtlasBaseActionsTest extends AtlasMappingBaseTest {
 
     @Test
     public void runStringLengthTest() throws Exception {
-        this.runActionTest(new StringLength(), "fname", stringLengthTestResultIsInteger ? 5 : "5");
+        this.runActionTest(new StringLength(), "fname", Integer.valueOf(5), Integer.class);
     }
 
     public abstract Object createInput(String inputFirstName);
 
-    public abstract Object getOutputValue(Object output);
+    public abstract Object getOutputValue(Object output, Class<?> outputClassExpected);
 }

--- a/atlas-itests-parent/atlas-itests-reference-mappings/src/test/java/io/atlasmap/reference/java_to_java/JavaJavaFieldActionsTest.java
+++ b/atlas-itests-parent/atlas-itests-reference-mappings/src/test/java/io/atlasmap/reference/java_to_java/JavaJavaFieldActionsTest.java
@@ -27,14 +27,14 @@ public class JavaJavaFieldActionsTest extends AtlasBaseActionsTest {
     @Override
     public void runStringLengthTest() throws Exception {
         this.outputField = createField("/boxedIntField");
-        this.runActionTest(new StringLength(), "fname", new Integer(5));
+        this.runActionTest(new StringLength(), "fname", new Integer(5), Integer.class);
         this.outputField = createField("/boxedStringField");
     }
 
     @Test
     public void runNoConversionTest() throws Exception {
         this.outputField = createField("/boxedIntField");
-        this.runActionTestList(null, "fname", null);
+        this.runActionTestList(null, "fname", null, String.class);
         this.outputField = createField("/boxedStringField");
     }
 
@@ -45,7 +45,7 @@ public class JavaJavaFieldActionsTest extends AtlasBaseActionsTest {
         return c;
     }
 
-    public Object getOutputValue(Object output) {
+    public Object getOutputValue(Object output, Class<?> outputClassExpected) {
         System.out.println("Extracting output value from: " + output);
         TargetFlatPrimitiveClass c = (TargetFlatPrimitiveClass) output;
         Object result = c.getBoxedStringField();

--- a/atlas-itests-parent/atlas-itests-reference-mappings/src/test/java/io/atlasmap/reference/json_to_json/JsonJsonFieldActionsTest.java
+++ b/atlas-itests-parent/atlas-itests-reference-mappings/src/test/java/io/atlasmap/reference/json_to_json/JsonJsonFieldActionsTest.java
@@ -25,12 +25,23 @@ public class JsonJsonFieldActionsTest extends AtlasBaseActionsTest {
         return "{ \"contact\": { \"firstName\": \"" + inputFirstName + "\" } }";
     }
 
-    public Object getOutputValue(Object output) {
+    public Object getOutputValue(Object output, Class<?> outputClassExpected) {
         System.out.println("Extracting output value from: " + output);
         String result = (String) output;
-        result = result.substring("{\"contact\":{\"firstName\":\"".length());
-        result = result.substring(0, result.length() - "\"}}".length());
-        System.out.println("Output value extracted: " + result);
+
+        if(outputClassExpected != null && outputClassExpected.equals(Integer.class)) {
+            result = result.substring("{\"contact\":{\"firstName\":".length());
+            result = result.substring(0, result.length() - "}}".length());
+            return Integer.valueOf(result);
+        } else if(outputClassExpected != null && outputClassExpected.equals(Boolean.class)) {
+            result = result.substring("{\"contact\":{\"firstName\":".length());
+            result = result.substring(0, result.length() - "}}".length());
+            return Boolean.valueOf(result);
+        } else {
+            // everything else is a string for JSON
+            result = result.substring("{\"contact\":{\"firstName\":\"".length());
+            result = result.substring(0, result.length() - "\"}}".length());
+        }
         return result;
     }
 

--- a/atlas-itests-parent/atlas-itests-reference-mappings/src/test/java/io/atlasmap/reference/xml_to_xml/XmlXmlFieldActionsTest.java
+++ b/atlas-itests-parent/atlas-itests-reference-mappings/src/test/java/io/atlasmap/reference/xml_to_xml/XmlXmlFieldActionsTest.java
@@ -26,13 +26,16 @@ public class XmlXmlFieldActionsTest extends AtlasBaseActionsTest {
                 + "</firstName></contact>";
     }
 
-    public Object getOutputValue(Object output) {
+    public Object getOutputValue(Object output, Class<?> ouputClassExpected) {
         System.out.println("Extracting output value from: " + output);
         String result = (String) output;
-        result = result
-                .substring("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><contact><firstName>".length());
+        result = result.substring("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><contact><firstName>".length());
         result = result.substring(0, result.length() - "</firstName></contact>".length());
         System.out.println("Output value extracted: " + result);
+
+        if(ouputClassExpected != null && ouputClassExpected.equals(Integer.class)) {
+            return Integer.valueOf(result);
+        }
         return result;
     }
 }

--- a/atlas-java-parent/atlas-java-module/src/main/java/io/atlasmap/java/module/OutputValueConverter.java
+++ b/atlas-java-parent/atlas-java-module/src/main/java/io/atlasmap/java/module/OutputValueConverter.java
@@ -98,8 +98,7 @@ public class OutputValueConverter implements JavaFieldWriterValueConverter {
             return populateEnumValue((JavaEnumField) inputField, (JavaEnumField) outputField);
         }
 
-        AtlasFieldActionService fieldActionService = session.getAtlasContext().getContextFactory()
-                .getFieldActionService();
+        AtlasFieldActionService fieldActionService = session.getAtlasContext().getContextFactory().getFieldActionService();
         try {
             outputValue = fieldActionService.processActions(outputField.getActions(), inputValue, outputType);
             if (outputValue != null) {

--- a/atlas-model/pom.xml
+++ b/atlas-model/pom.xml
@@ -81,8 +81,25 @@
                             <schemaDirectory>${xsd.folder}</schemaDirectory>
                             <bindingDirectory>${xjb.folder}</bindingDirectory>
                             <schemaExcludes>
-                                <include>**/atlas-actions-v3.xsd</include>
+                                <schemaExclude>**/atlas-actions-v2.xsd</schemaExclude>
                             </schemaExcludes>
+                            <args><arg>-Xannotate</arg><arg>-Xinheritance</arg></args>
+                            <plugins>
+                               <plugin>
+                                  <groupId>org.jvnet.jaxb2_commons</groupId>
+                                  <artifactId>jaxb2-basics</artifactId>
+                                  <version>0.11.1</version>
+                               </plugin>
+                               <plugin>
+                                  <groupId>org.jvnet.jaxb2_commons</groupId>
+                                  <artifactId>jaxb2-basics-annotate</artifactId>
+                                  <version>1.0.4</version>
+                                </plugin>
+                                <plugin>
+                                   <groupId>com.fasterxml.jackson.core</groupId>
+                                   <artifactId>jackson-databind</artifactId>
+                                </plugin>
+                            </plugins>
                         </configuration>
                     </execution>
                 </executions>

--- a/atlas-model/src/main/java/io/atlasmap/v2/FieldAction.java
+++ b/atlas-model/src/main/java/io/atlasmap/v2/FieldAction.java
@@ -1,0 +1,8 @@
+package io.atlasmap.v2;
+
+public interface FieldAction {
+
+    default String getDisplayName() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/atlas-model/src/main/resources/atlas-actions-v2.xsd
+++ b/atlas-model/src/main/resources/atlas-actions-v2.xsd
@@ -13,7 +13,6 @@
     <complexType name="Action" abstract="true" />
 
     <!-- String Actions -->
-
     <element name="Camelize">
         <complexType>
             <complexContent>

--- a/atlas-model/src/main/resources/atlas-model-v2.xjb
+++ b/atlas-model/src/main/resources/atlas-model-v2.xjb
@@ -2,6 +2,7 @@
 <jaxb:bindings xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema"
                xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xmlns:annox="http://annox.dev.java.net"
+               xmlns:inheritance="http://jaxb2-commons.dev.java.net/basic/inheritance"
                xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
                jaxb:extensionBindingPrefixes="xjc annox"
                version="2.1">
@@ -19,6 +20,9 @@
         </jaxb:bindings>
         <jaxb:bindings node="xs:complexType[@name='Actions']//xs:choice">
             <jaxb:property name="actions"/>
+        </jaxb:bindings>
+        <jaxb:bindings node="//xs:complexType[@name='Action']">
+            <inheritance:implements>io.atlasmap.v2.FieldAction</inheritance:implements> 
         </jaxb:bindings>
     </jaxb:bindings>
     


### PR DESCRIPTION
#216 Update DefaultFieldActionService to support overloaded FieldAction names

 - First pass of implementation, modifying the lookup of FieldActions to use the sourceType as a hint when multiple FieldActions exist with the same name