### PR TITLE
fix(atlas-java): Java inspection forces FieldType to COMPLEX for othe…

### DIFF
--- a/atlas-api/src/main/java/io/atlasmap/api/AtlasConversionService.java
+++ b/atlas-api/src/main/java/io/atlasmap/api/AtlasConversionService.java
@@ -22,11 +22,11 @@ import java.util.Optional;
 
 public interface AtlasConversionService {
 
-    Optional<AtlasConverter> findMatchingConverter(FieldType source, FieldType target);
+    Optional<AtlasConverter<?>> findMatchingConverter(FieldType source, FieldType target);
 
-    Optional<AtlasConverter> findMatchingConverter(String sourceClassName, String targetClassName);
+    Optional<AtlasConverter<?>> findMatchingConverter(String sourceClassName, String targetClassName);
 
-    Optional<Method> findMatchingMethod(FieldType source, FieldType target, AtlasConverter customConverter);
+    Optional<Method> findMatchingMethod(FieldType source, FieldType target, AtlasConverter<?> customConverter);
 
     Object copyPrimitive(Object sourceValue);
 

--- a/atlas-core/src/main/java/io/atlasmap/core/BaseModuleValidationService.java
+++ b/atlas-core/src/main/java/io/atlasmap/core/BaseModuleValidationService.java
@@ -245,7 +245,7 @@ public abstract class BaseModuleValidationService<T extends Field> implements At
     protected void validateFieldTypeConversion(Field inputField, Field outField, List<Validation> validations) {
         FieldType inFieldType = inputField.getFieldType();
         FieldType outFieldType = outField.getFieldType();
-        Optional<AtlasConverter> atlasConverter = conversionService.findMatchingConverter(inFieldType, outFieldType);
+        Optional<AtlasConverter<?>> atlasConverter = conversionService.findMatchingConverter(inFieldType, outFieldType);
         String rejectedValue = getFieldName(inputField) + " --> " + getFieldName(outField);
         if (!atlasConverter.isPresent()) {
             Validation validation = new Validation();

--- a/atlas-core/src/test/java/io/atlasmap/core/DefaultAtlasConversionServiceTest.java
+++ b/atlas-core/src/test/java/io/atlasmap/core/DefaultAtlasConversionServiceTest.java
@@ -67,7 +67,7 @@ public class DefaultAtlasConversionServiceTest {
     @SuppressWarnings("unchecked")
     public void findMatchingConverterByFieldTypes() throws Exception {
         assertNotNull(service);
-        Optional<AtlasConverter> atlasConverter = service.findMatchingConverter(FieldType.STRING, FieldType.BOOLEAN);
+        Optional<AtlasConverter<?>> atlasConverter = service.findMatchingConverter(FieldType.STRING, FieldType.BOOLEAN);
         assertTrue(atlasConverter.isPresent());
         assertNotNull(atlasConverter);
         assertTrue(AtlasPrimitiveConverter.class.isAssignableFrom(atlasConverter.get().getClass()));
@@ -85,7 +85,7 @@ public class DefaultAtlasConversionServiceTest {
     @Test
     public void findMatchingConverterByFieldTypesCustomConverter() throws Exception {
         assertNotNull(service);
-        Optional<AtlasConverter> atlasConverter = service.findMatchingConverter(FieldType.STRING, FieldType.STRING);
+        Optional<AtlasConverter<?>> atlasConverter = service.findMatchingConverter(FieldType.STRING, FieldType.STRING);
         assertNotNull(atlasConverter);
         assertTrue(atlasConverter.isPresent());
         assertTrue(AtlasConverter.class.isAssignableFrom(atlasConverter.get().getClass()));
@@ -95,14 +95,14 @@ public class DefaultAtlasConversionServiceTest {
     @Test
     public void findMatchingConverterByFieldTypesNoMatching() throws Exception {
         assertNotNull(service);
-        Optional<AtlasConverter> atlasConverter = service.findMatchingConverter(FieldType.STRING, FieldType.COMPLEX);
+        Optional<AtlasConverter<?>> atlasConverter = service.findMatchingConverter(FieldType.STRING, FieldType.COMPLEX);
         assertFalse(atlasConverter.isPresent());
     }
 
     @Test
     public void findMatchingConverterBySourceClass() throws Exception {
         assertNotNull(service);
-        Optional<AtlasConverter> atlasConverter = service.findMatchingConverter("java.util.Date",
+        Optional<AtlasConverter<?>> atlasConverter = service.findMatchingConverter("java.util.Date",
                 "java.time.ZonedDateTime");
         assertNotNull(atlasConverter);
         assertTrue(atlasConverter.isPresent());
@@ -113,7 +113,7 @@ public class DefaultAtlasConversionServiceTest {
     @Test
     public void findMatchingConverterBySourceClassNoMatching() throws Exception {
         assertNotNull(service);
-        Optional<AtlasConverter> atlasConverter = service.findMatchingConverter("java.util.Date",
+        Optional<AtlasConverter<?>> atlasConverter = service.findMatchingConverter("java.util.Date",
                 "java.time.CustomClass");
         assertFalse(atlasConverter.isPresent());
     }
@@ -121,8 +121,8 @@ public class DefaultAtlasConversionServiceTest {
     @Test
     public void findMatchingMethodByFieldTypes() throws Exception {
         assertNotNull(service);
-        Optional<AtlasConverter> atlasConverter = service.findMatchingConverter(FieldType.STRING, FieldType.BOOLEAN);
-        AtlasConverter converter = atlasConverter.orElse(null);
+        Optional<AtlasConverter<?>> atlasConverter = service.findMatchingConverter(FieldType.STRING, FieldType.BOOLEAN);
+        AtlasConverter<?> converter = atlasConverter.orElse(null);
         assertNotNull(converter);
         Optional<Method> methods = service.findMatchingMethod(FieldType.STRING, FieldType.BOOLEAN,
                 atlasConverter.orElseGet(null));
@@ -154,7 +154,7 @@ public class DefaultAtlasConversionServiceTest {
 
         assertFalse(service.isPrimitive(AtlasMapping.class));
         assertFalse(service.isPrimitive(List.class));
-        assertFalse(service.isPrimitive((Class) null));
+        assertFalse(service.isPrimitive((Class<?>) null));
     }
 
     @Test
@@ -207,7 +207,7 @@ public class DefaultAtlasConversionServiceTest {
 
         assertFalse(service.isBoxedPrimitive(AtlasMapping.class));
         assertFalse(service.isBoxedPrimitive(List.class));
-        assertFalse(service.isBoxedPrimitive(null));
+        assertFalse(service.isBoxedPrimitive((Class<?>)null));
     }
 
     @Test

--- a/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/ClassInspectionServiceTest.java
+++ b/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/ClassInspectionServiceTest.java
@@ -20,14 +20,21 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.atlasmap.core.DefaultAtlasConversionService;
+import io.atlasmap.java.v2.JavaClass;
+import io.atlasmap.java.v2.JavaField;
+import io.atlasmap.java.v2.Modifier;
+import io.atlasmap.v2.FieldType;
 
 import java.io.File;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ClassInspectionServiceTest {
 
@@ -98,6 +105,195 @@ public class ClassInspectionServiceTest {
         assertEquals(File.separator + "foo.jar", cis.classpathStringToList(tmpcp).get(0));
         assertEquals(File.separator + "bar.jar", cis.classpathStringToList(tmpcp).get(1));
         assertEquals(File.separator + "blah.jar", cis.classpathStringToList(tmpcp).get(2));
+    }
+
+    @Test
+    public void testDateTimeViaField() {
+        JavaClass javaClass = classInspectionService.inspectClass(DateTimeField.class);
+        // FIXME java.time.Month is Enum - https://github.com/atlasmap/atlasmap-runtime/issues/251
+        // assertEquals(10, javaClass.getJavaFields().getJavaField().size());
+        assertEquals(9, javaClass.getJavaFields().getJavaField().size());
+        assertFalse(javaClass.getModifiers().getModifier().contains(Modifier.PRIVATE));
+        assertFalse(javaClass.getModifiers().getModifier().contains(Modifier.PROTECTED));
+        assertFalse(javaClass.getModifiers().getModifier().contains(Modifier.PUBLIC));
+        assertTrue(javaClass.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+        for (JavaField field : javaClass.getJavaFields().getJavaField()) {
+            if ("year".equals(field.getName())) {
+                assertEquals("java.time.Year", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PRIVATE));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PROTECTED));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PUBLIC));
+                assertTrue(field.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+            } else if ("month".equals(field.getName())) {
+                assertEquals("java.time.Month", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PRIVATE));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PROTECTED));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PUBLIC));
+                assertTrue(field.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+            } else if ("yearMonth".equals(field.getName())) {
+                assertEquals("java.time.YearMonth", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PRIVATE));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PROTECTED));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PUBLIC));
+                assertTrue(field.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+            } else if ("monthDay".equals(field.getName())) {
+                assertEquals("java.time.MonthDay", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PRIVATE));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PROTECTED));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PUBLIC));
+                assertTrue(field.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+            } else if ("localDate".equals(field.getName())) {
+                assertEquals("java.time.LocalDate", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PRIVATE));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PROTECTED));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PUBLIC));
+                assertTrue(field.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+            } else if ("localTime".equals(field.getName())) {
+                assertEquals("java.time.LocalTime", field.getClassName());
+                assertEquals(FieldType.TIME, field.getFieldType());
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PRIVATE));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PROTECTED));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PUBLIC));
+                assertTrue(field.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+            } else if ("localDateTime".equals(field.getName())) {
+                assertEquals("java.time.LocalDateTime", field.getClassName());
+                assertEquals(FieldType.DATE_TIME, field.getFieldType());
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PRIVATE));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PROTECTED));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PUBLIC));
+                assertTrue(field.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+            } else if ("zonedDateTime".equals(field.getName())) {
+                assertEquals("java.time.ZonedDateTime", field.getClassName());
+                assertEquals(FieldType.DATE_TIME_TZ, field.getFieldType());
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PRIVATE));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PROTECTED));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PUBLIC));
+                assertTrue(field.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+            } else if ("date".equals(field.getName())) {
+                assertEquals("java.util.Date", field.getClassName());
+                assertEquals(FieldType.DATE_TIME_TZ, field.getFieldType());
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PRIVATE));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PROTECTED));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PUBLIC));
+                assertTrue(field.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+            } else if ("sqlDate".equals(field.getName())) {
+                assertEquals("java.sql.Date", field.getClassName());
+                assertEquals(FieldType.DATE_TIME_TZ, field.getFieldType());
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PRIVATE));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PROTECTED));
+                assertFalse(field.getModifiers().getModifier().contains(Modifier.PUBLIC));
+                assertTrue(field.getModifiers().getModifier().contains(Modifier.PACKAGE_PRIVATE));
+            } else {
+                fail("Unsupported field was detected: " + field);
+            }
+        }
+    }
+
+    @Test
+    public void testDateTimeViaGetter() {
+        JavaClass javaClass = classInspectionService.inspectClass(DateTimeGetter.class);
+        assertEquals(10, javaClass.getJavaFields().getJavaField().size());
+        for (JavaField field : javaClass.getJavaFields().getJavaField()) {
+            if ("year".equals(field.getName())) {
+                assertEquals("java.time.Year", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertEquals("getYear", field.getGetMethod());
+            } else if ("month".equals(field.getName())) {
+                assertEquals("java.time.Month", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertEquals("getMonth", field.getGetMethod());
+            } else if ("yearMonth".equals(field.getName())) {
+                assertEquals("java.time.YearMonth", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertEquals("getYearMonth", field.getGetMethod());
+            } else if ("monthDay".equals(field.getName())) {
+                assertEquals("java.time.MonthDay", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertEquals("getMonthDay", field.getGetMethod());
+            } else if ("localDate".equals(field.getName())) {
+                assertEquals("java.time.LocalDate", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertEquals("getLocalDate", field.getGetMethod());
+            } else if ("localTime".equals(field.getName())) {
+                assertEquals("java.time.LocalTime", field.getClassName());
+                assertEquals(FieldType.TIME, field.getFieldType());
+                assertEquals("getLocalTime", field.getGetMethod());
+            } else if ("localDateTime".equals(field.getName())) {
+                assertEquals("java.time.LocalDateTime", field.getClassName());
+                assertEquals(FieldType.DATE_TIME, field.getFieldType());
+                assertEquals("getLocalDateTime", field.getGetMethod());
+            } else if ("zonedDateTime".equals(field.getName())) {
+                assertEquals("java.time.ZonedDateTime", field.getClassName());
+                assertEquals(FieldType.DATE_TIME_TZ, field.getFieldType());
+                assertEquals("getZonedDateTime", field.getGetMethod());
+            } else if ("date".equals(field.getName())) {
+                assertEquals("java.util.Date", field.getClassName());
+                assertEquals(FieldType.DATE_TIME_TZ, field.getFieldType());
+                assertEquals("getDate", field.getGetMethod());
+            } else if ("sqlDate".equals(field.getName())) {
+                assertEquals("java.sql.Date", field.getClassName());
+                assertEquals(FieldType.DATE_TIME_TZ, field.getFieldType());
+                assertEquals("getSqlDate", field.getGetMethod());
+            } else {
+                fail("Unsupported field was detected: " + field);
+            }
+        }
+    }
+
+    @Test
+    public void testDateTimeViaSetter() {
+        JavaClass javaClass = classInspectionService.inspectClass(DateTimeSetter.class);
+        assertEquals(10, javaClass.getJavaFields().getJavaField().size());
+        for (JavaField field : javaClass.getJavaFields().getJavaField()) {
+            if ("year".equals(field.getName())) {
+                assertEquals("java.time.Year", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertEquals("setYear", field.getSetMethod());
+            } else if ("month".equals(field.getName())) {
+                assertEquals("java.time.Month", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertEquals("setMonth", field.getSetMethod());
+            } else if ("yearMonth".equals(field.getName())) {
+                assertEquals("java.time.YearMonth", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertEquals("setYearMonth", field.getSetMethod());
+            } else if ("monthDay".equals(field.getName())) {
+                assertEquals("java.time.MonthDay", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertEquals("setMonthDay", field.getSetMethod());
+            } else if ("localDate".equals(field.getName())) {
+                assertEquals("java.time.LocalDate", field.getClassName());
+                assertEquals(FieldType.DATE, field.getFieldType());
+                assertEquals("setLocalDate", field.getSetMethod());
+            } else if ("localTime".equals(field.getName())) {
+                assertEquals("java.time.LocalTime", field.getClassName());
+                assertEquals(FieldType.TIME, field.getFieldType());
+                assertEquals("setLocalTime", field.getSetMethod());
+            } else if ("localDateTime".equals(field.getName())) {
+                assertEquals("java.time.LocalDateTime", field.getClassName());
+                assertEquals(FieldType.DATE_TIME, field.getFieldType());
+                assertEquals("setLocalDateTime", field.getSetMethod());
+            } else if ("zonedDateTime".equals(field.getName())) {
+                assertEquals("java.time.ZonedDateTime", field.getClassName());
+                assertEquals(FieldType.DATE_TIME_TZ, field.getFieldType());
+                assertEquals("setZonedDateTime", field.getSetMethod());
+            } else if ("date".equals(field.getName())) {
+                assertEquals("java.util.Date", field.getClassName());
+                assertEquals(FieldType.DATE_TIME_TZ, field.getFieldType());
+                assertEquals("setDate", field.getSetMethod());
+            } else if ("sqlDate".equals(field.getName())) {
+                assertEquals("java.sql.Date", field.getClassName());
+                assertEquals(FieldType.DATE_TIME_TZ, field.getFieldType());
+                assertEquals("setSqlDate", field.getSetMethod());
+            } else {
+                fail("Unsupported field was detected: " + field);
+            }
+        }
     }
 
 }

--- a/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/DateTimeField.java
+++ b/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/DateTimeField.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.java.inspect;
+
+class DateTimeField {
+    java.time.Year year;
+    java.time.Month month;
+    java.time.YearMonth yearMonth;
+    java.time.MonthDay monthDay;
+    java.time.LocalDate localDate;
+    java.time.LocalTime localTime;
+    java.time.LocalDateTime localDateTime;
+    java.time.ZonedDateTime zonedDateTime;
+    java.util.Date date;
+    java.sql.Date sqlDate;
+}

--- a/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/DateTimeGetter.java
+++ b/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/DateTimeGetter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.java.inspect;
+
+public interface DateTimeGetter {
+    java.time.Year getYear();
+    java.time.Month getMonth();
+    java.time.YearMonth getYearMonth();
+    java.time.MonthDay getMonthDay();
+    java.time.LocalDate getLocalDate();
+    java.time.LocalTime getLocalTime();
+    java.time.LocalDateTime getLocalDateTime();
+    java.time.ZonedDateTime getZonedDateTime();
+    java.util.Date getDate();
+    java.sql.Date getSqlDate();
+}

--- a/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/DateTimeSetter.java
+++ b/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/DateTimeSetter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atlasmap.java.inspect;
+
+interface DateTimeSetter {
+    void setYear(java.time.Year year);
+    void setMonth(java.time.Month month);
+    void setYearMonth(java.time.YearMonth yearMonth);
+    void setMonthDay(java.time.MonthDay monthDay);
+    void setLocalDate(java.time.LocalDate localDate);
+    void setLocalTime(java.time.LocalTime localTime);
+    void setLocalDateTime(java.time.LocalDateTime localDateTime);
+    void setZonedDateTime(java.time.ZonedDateTime zonedDateTime);
+    void setDate(java.util.Date date);
+    void setSqlDate(java.sql.Date sqlDate);
+}

--- a/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/TestListOrdersTest.java
+++ b/atlas-java-parent/atlas-java-inspect/src/test/java/io/atlasmap/java/inspect/TestListOrdersTest.java
@@ -84,6 +84,9 @@ public class TestListOrdersTest {
                 } else {
                     fail("Unexpected class: " + ((JavaClass) c2f).getClassName());
                 }
+            } else if ("java.util.Date".equals(c2f.getClassName())) {
+                ClassValidationUtil.validateCreated(c2f);
+                foundCreated = true;
             }
         }
 

--- a/atlas-java-parent/atlas-java-model/src/main/resources/atlas-java-model-v2.xsd
+++ b/atlas-java-parent/atlas-java-model/src/main/resources/atlas-java-model-v2.xsd
@@ -163,6 +163,7 @@
             <enumeration value="Final" />
             <enumeration value="Interface" />
             <enumeration value="Native" />
+            <enumeration value="Package Private" />
             <enumeration value="Public" />
             <enumeration value="Protected" />
             <enumeration value="Private" />

--- a/atlas-java-parent/atlas-java-module/src/main/java/io/atlasmap/java/module/JavaValidationService.java
+++ b/atlas-java-parent/atlas-java-module/src/main/java/io/atlasmap/java/module/JavaValidationService.java
@@ -141,7 +141,7 @@ public class JavaValidationService extends BaseModuleValidationService<JavaField
     }
 
     private void validateClassConversion(JavaField inputField, JavaField outField, List<Validation> validations) {
-        Optional<AtlasConverter> atlasConverter = getConversionService().findMatchingConverter(
+        Optional<AtlasConverter<?>> atlasConverter = getConversionService().findMatchingConverter(
                 inputField.getClassName(), outField.getClassName());
         String rejectedValue = getFieldName(inputField) + " --> " + getFieldName(outField);
         if (!atlasConverter.isPresent()) {

--- a/atlas-service-parent/atlas-service/src/main/java/io/atlasmap/service/AtlasService.java
+++ b/atlas-service-parent/atlas-service/src/main/java/io/atlasmap/service/AtlasService.java
@@ -368,10 +368,10 @@ public class AtlasService extends Application {
                     outputType = ((JavaField) outputField).getFieldType();
                 }
 
-                Optional<AtlasConverter> optionalConverter = conversionService.findMatchingConverter(inputType,
+                Optional<AtlasConverter<?>> optionalConverter = conversionService.findMatchingConverter(inputType,
                         outputType);
                 if (optionalConverter.isPresent()) {
-                    AtlasConverter converter = optionalConverter.get();
+                    AtlasConverter<?> converter = optionalConverter.get();
                     // TODO: return "ok"
                 } else {
                     // TODO: return "Converter needed"


### PR DESCRIPTION
…r than primitives, which breaks DATE/TIME related types

Fixes: #234

Also addresses:

Java inspection should not inspect JDK classes
Fixes: #252

Java field inspection ignores package private fields
Fixes: #253

Add an inspection unit test with package private Class to confirm class accessibility issues
Fixes: #85