### PR TITLE
fix(atlas-json): JsonFieldReader must use get() instead of findValue(…

### DIFF
--- a/atlas-itests-parent/atlas-itests-reference-mappings/src/test/java/io/atlasmap/reference/json_to_json/JsonJsonCollectionConversionTest.java
+++ b/atlas-itests-parent/atlas-itests-reference-mappings/src/test/java/io/atlasmap/reference/json_to_json/JsonJsonCollectionConversionTest.java
@@ -106,7 +106,7 @@ public class JsonJsonCollectionConversionTest extends AtlasMappingBaseTest {
 
         // contact.firstName -> contact<>.name
 
-        String input = "{ \"contact\": [ { \"firstName\": \"name9\" } ] }";
+        String input = "{ \"contact\": { \"firstName\": \"name9\" } }";
         AtlasSession session = context.createSession();
         session.setInput(input);
         context.process(session);

--- a/atlas-json-parent/atlas-json-core/src/main/java/io/atlasmap/json/core/JsonFieldReader.java
+++ b/atlas-json-parent/atlas-json-core/src/main/java/io/atlasmap/json/core/JsonFieldReader.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atlasmap.json.core;
 
 import com.fasterxml.jackson.core.JsonFactory;
@@ -8,159 +23,170 @@ import io.atlasmap.api.AtlasException;
 import io.atlasmap.json.v2.JsonField;
 import io.atlasmap.v2.CollectionType;
 import io.atlasmap.v2.FieldType;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JsonFieldReader {
 
     private static final Logger LOG = LoggerFactory.getLogger(JsonFieldReader.class);
+    private JsonNode rootNode;
 
-    public void read(final String document, final JsonField jsonField) throws AtlasException {
+    public void setDocument(String document) throws AtlasException {
         if (document == null || document.isEmpty()) {
-            throw new AtlasException(new IllegalArgumentException("Argument 'document' cannot be null nor empty"));
+            throw new AtlasException(new IllegalArgumentException("document cannot be null nor empty"));
         }
-        if (jsonField == null) {
-            throw new AtlasException(new IllegalArgumentException("Argument 'jsonField' cannot be null"));
-        }
-        // make this a JSON document
-        JsonFactory jsonFactory = new JsonFactory();
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonParser parser;
-        JsonNode rootNode;
-        JsonNode valueNode = null;
+
         try {
-            parser = jsonFactory.createParser(document);
-            rootNode = objectMapper.readTree(parser);
-            String[] nodes = jsonField.getPath().replaceFirst("/", "").split("/");
-            int index = 0;
-            if (nodes.length == 1) {
-                valueNode = rootNode.findValue(nodes[0]);
-            } else if (nodes.length > 1) {
-                valueNode = rootNode;
-                // need to walk the path....
-                for (String nodeName : nodes) {
-                    // are we looking for an array?
-                    if (nodeName.contains("[")) {
-                        index = Integer.parseInt(nodeName.substring(nodeName.indexOf("[") + 1, nodeName.indexOf("]")));
-                        nodeName = nodeName.substring(0, nodeName.indexOf("["));
-                    }
-                    // maybe a list?
-                    if (nodeName.contains("<")) {
-                        index = Integer.parseInt(nodeName.substring(nodeName.indexOf("<") + 1, nodeName.indexOf(">")));
-                        nodeName = nodeName.substring(0, nodeName.indexOf("<"));
-                    }
-                    if (valueNode != null && valueNode.isArray() && index > 0) {
-                        valueNode = valueNode.get(index);
-                        // reset for possible indexed child nodes
-                        index = 0;
-                    }
-                    if (valueNode != null) {
-                        valueNode = valueNode.findValue(nodeName);
-                    } else {
-                        // TODO: JsonReader System.out.println("----> should we log this miss?");
-                        valueNode = null;
-                        break;
-                    }
-                }
-            }
-            if (valueNode != null) {
-                if (valueNode.isTextual()) {
-                    if (jsonField.getFieldType() == null || FieldType.STRING.equals(jsonField.getFieldType())) {
-                        jsonField.setValue(valueNode.textValue());
-                        jsonField.setFieldType(FieldType.STRING);
-                    } else {
-                        if (FieldType.CHAR.equals(jsonField.getFieldType())) {
-                            jsonField.setValue(valueNode.textValue().charAt(0));
-                        } else {
-                            LOG.warn(String.format("Unsupported FieldType for text data t=%s p=%s docId=%s",
-                                    jsonField.getFieldType().value(), jsonField.getPath(), jsonField.getDocId()));
-                        }
-                    }
-                } else if (valueNode.isNumber()) {
-                    if (valueNode.isInt()) {
-                        jsonField.setValue(valueNode.intValue());
-                        jsonField.setFieldType(FieldType.INTEGER);
-                    } else if (valueNode.isDouble()) {
-                        jsonField.setValue(valueNode.doubleValue());
-                        jsonField.setFieldType(FieldType.DOUBLE);
-                    } else if (valueNode.isBigDecimal()) {
-                        jsonField.setValue(valueNode.decimalValue());
-                        jsonField.setFieldType(FieldType.DECIMAL);
-                    } else if (valueNode.isFloat()) {
-                        jsonField.setValue(valueNode.floatValue());
-                        jsonField.setFieldType(FieldType.DOUBLE);
-                    } else if (valueNode.isLong()) {
-                        jsonField.setValue(valueNode.longValue());
-                        jsonField.setFieldType(FieldType.LONG);
-                    } else if (valueNode.isShort()) {
-                        jsonField.setValue(valueNode.shortValue());
-                        jsonField.setFieldType(FieldType.SHORT);
-                    } else if (valueNode.isBigInteger()) {
-                        jsonField.setValue(valueNode.bigIntegerValue());
-                        jsonField.setFieldType(FieldType.NUMBER);
-                    } else {
-                        jsonField.setValue(valueNode.numberValue());
-                        jsonField.setFieldType(FieldType.NUMBER);
-                    }
-                } else if (valueNode.isBoolean()) {
-                    jsonField.setValue(valueNode.booleanValue());
-                    jsonField.setFieldType(FieldType.BOOLEAN);
-                } else if (valueNode.isContainerNode()) {
-                    if (valueNode.isArray()) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug(String.format("Detected json array p=%s docId=%s", jsonField.getPath(),
-                                    jsonField.getDocId()));
-                        }
-                        jsonField.setValue(valueNode.toString());
-                        jsonField.setFieldType(FieldType.COMPLEX);
-                        jsonField.setCollectionType(CollectionType.ARRAY);
-                    } else if (valueNode.isObject()) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug(String.format("Detected json complex object p=%s docId=%s",
-                                    jsonField.getPath(), jsonField.getDocId()));
-                        }
-                        jsonField.setValue(valueNode.toString());
-                        jsonField.setFieldType(FieldType.COMPLEX);
-                    }
-                } else if (valueNode.isNull()) {
-                    jsonField.setValue(null);
-                    // we can't detect field type if it's null node
-                } else {
-                    LOG.warn(String.format("Detected unsupported json type for field p=%s docId=%s",
-                            jsonField.getPath(), jsonField.getDocId()));
-                    jsonField.setValue(valueNode.toString());
-                    jsonField.setFieldType(FieldType.UNSUPPORTED);
-                }
-            }
-        } catch (IOException e) {
+            JsonFactory factory = new JsonFactory();
+            ObjectMapper mapper = new ObjectMapper();
+            JsonParser parser = factory.createParser(document);
+            this.rootNode = mapper.readTree(parser);
+        } catch (Exception e) {
             throw new AtlasException(e);
         }
     }
 
-    public Integer getCollectionCount(final String document, final JsonField jsonField, final String collectionSegment)
-            throws AtlasException {
-        if (document == null || document.isEmpty()) {
-            throw new AtlasException(new IllegalArgumentException("Argument 'document' cannot be null nor empty"));
+    public void read(final JsonField jsonField) throws AtlasException {
+        if (rootNode == null) {
+            throw new AtlasException("document is not set");
         }
         if (jsonField == null) {
             throw new AtlasException(new IllegalArgumentException("Argument 'jsonField' cannot be null"));
         }
-        // make this a JSON document
-        JsonFactory jsonFactory = new JsonFactory();
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonParser parser;
-        JsonNode rootNode;
-        try {
-            parser = jsonFactory.createParser(document);
-            rootNode = objectMapper.readTree(parser);
-            JsonNode collectionNode = rootNode.findValue(collectionSegment);
-            if (collectionNode != null && collectionNode.isArray()) {
-                return collectionNode.size();
+
+        JsonNode valueNode = null;
+        String path = jsonField.getPath();
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        String[] nodes = path.split("/");
+        if (nodes.length >= 1) {
+            if (rootNode.size() == 1 && !nodes[0].startsWith(rootNode.fieldNames().next())) {
+                // peel off a rooted object
+                valueNode = rootNode.elements().next();
+            } else {
+                valueNode = rootNode;
             }
-            return null;
-        } catch (IOException e) {
-            throw new AtlasException(e.getMessage(), e);
+
+            // need to walk the path....
+            for (String nodeName : nodes) {
+                if (valueNode == null) {
+                    break;
+                }
+                valueNode = getValueNode(valueNode, nodeName);
+            }
+        }
+        if (valueNode == null) {
+            jsonField.setFieldType(FieldType.NONE);
+            return;
+        }
+
+        if (valueNode.isTextual()) {
+            handleTextualNode(valueNode, jsonField);
+        } else if (valueNode.isNumber()) {
+            handleNumberNode(valueNode, jsonField);
+        } else if (valueNode.isBoolean()) {
+            handleBooleanNode(valueNode, jsonField);
+        } else if (valueNode.isContainerNode()) {
+            handleContainerNode(valueNode, jsonField);
+        } else if (valueNode.isNull()) {
+            jsonField.setValue(null);
+            // we can't detect field type if it's null node
+        } else {
+            LOG.warn(String.format("Detected unsupported json type for field p=%s docId=%s",
+                    jsonField.getPath(), jsonField.getDocId()));
+            jsonField.setValue(valueNode.toString());
+            jsonField.setFieldType(FieldType.UNSUPPORTED);
         }
     }
+
+    private JsonNode getValueNode(JsonNode parent, String nodeName) {
+        String strippedNodeName = nodeName;
+        Integer index = null;
+        if (nodeName.contains("[")) {
+            // are we looking for an array?
+            index = Integer.parseInt(nodeName.substring(nodeName.indexOf("[") + 1, nodeName.indexOf("]")));
+            strippedNodeName = nodeName.substring(0, nodeName.indexOf("["));
+        } else if (nodeName.contains("<")) {
+            // maybe a list?
+            index = Integer.parseInt(nodeName.substring(nodeName.indexOf("<") + 1, nodeName.indexOf(">")));
+            strippedNodeName = nodeName.substring(0, nodeName.indexOf("<"));
+        }
+        JsonNode answer = parent.get(strippedNodeName);
+        if (answer != null && answer.isArray() && index != null) {
+            if (index >= 0) {
+                answer = answer.get(index);
+            } else {
+                LOG.warn(String.format("Detected negative index for field p=%s, ignoring...", nodeName));
+            }
+        }
+        return answer;
+    }
+
+    private void handleTextualNode(JsonNode valueNode, JsonField jsonField) {
+        if (jsonField.getFieldType() == null || FieldType.STRING.equals(jsonField.getFieldType())) {
+            jsonField.setValue(valueNode.textValue());
+            jsonField.setFieldType(FieldType.STRING);
+        } else {
+            if (FieldType.CHAR.equals(jsonField.getFieldType())) {
+                jsonField.setValue(valueNode.textValue().charAt(0));
+            } else {
+                LOG.warn(String.format("Unsupported FieldType for text data t=%s p=%s docId=%s",
+                        jsonField.getFieldType().value(), jsonField.getPath(), jsonField.getDocId()));
+            }
+        }
+    }
+
+    private void handleNumberNode(JsonNode valueNode, JsonField jsonField) {
+        if (valueNode.isInt()) {
+            jsonField.setValue(valueNode.intValue());
+            jsonField.setFieldType(FieldType.INTEGER);
+        } else if (valueNode.isDouble()) {
+            jsonField.setValue(valueNode.doubleValue());
+            jsonField.setFieldType(FieldType.DOUBLE);
+        } else if (valueNode.isBigDecimal()) {
+            jsonField.setValue(valueNode.decimalValue());
+            jsonField.setFieldType(FieldType.DECIMAL);
+        } else if (valueNode.isFloat()) {
+            jsonField.setValue(valueNode.floatValue());
+            jsonField.setFieldType(FieldType.DOUBLE);
+        } else if (valueNode.isLong()) {
+            jsonField.setValue(valueNode.longValue());
+            jsonField.setFieldType(FieldType.LONG);
+        } else if (valueNode.isShort()) {
+            jsonField.setValue(valueNode.shortValue());
+            jsonField.setFieldType(FieldType.SHORT);
+        } else if (valueNode.isBigInteger()) {
+            jsonField.setValue(valueNode.bigIntegerValue());
+            jsonField.setFieldType(FieldType.NUMBER);
+        } else {
+            jsonField.setValue(valueNode.numberValue());
+            jsonField.setFieldType(FieldType.NUMBER);
+        }
+    }
+
+    private void handleBooleanNode(JsonNode valueNode, JsonField jsonField) {
+        jsonField.setValue(valueNode.booleanValue());
+        jsonField.setFieldType(FieldType.BOOLEAN);
+    }
+
+    private void handleContainerNode(JsonNode valueNode, JsonField jsonField) {
+        if (valueNode.isArray()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Detected json array p=%s docId=%s", jsonField.getPath(),
+                        jsonField.getDocId()));
+            }
+            jsonField.setValue(valueNode.toString());
+            jsonField.setFieldType(FieldType.COMPLEX);
+            jsonField.setCollectionType(CollectionType.ARRAY);
+        } else if (valueNode.isObject()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Detected json complex object p=%s docId=%s",
+                        jsonField.getPath(), jsonField.getDocId()));
+            }
+            jsonField.setValue(valueNode.toString());
+            jsonField.setFieldType(FieldType.COMPLEX);
+        }
+    }
+
 }

--- a/atlas-json-parent/atlas-json-core/src/test/java/io/atlasmap/json/core/JsonFieldReaderTest.java
+++ b/atlas-json-parent/atlas-json-core/src/test/java/io/atlasmap/json/core/JsonFieldReaderTest.java
@@ -20,30 +20,34 @@ public class JsonFieldReaderTest {
 
     @Test(expected = AtlasException.class)
     public void testWithNullDocument() throws Exception {
-        reader.read(null, AtlasJsonModelFactory.createJsonField());
+        reader.setDocument(null);
+        reader.read(AtlasJsonModelFactory.createJsonField());
     }
 
     @Test(expected = AtlasException.class)
     public void testWithEmptyDocument() throws Exception {
-        reader.read("", AtlasJsonModelFactory.createJsonField());
+        reader.setDocument("");
+        reader.read(AtlasJsonModelFactory.createJsonField());
     }
 
     @Test(expected = AtlasException.class)
     public void testWithNullJsonField() throws Exception {
-        reader.read("{qwerty : ytrewq}", null);
+        reader.setDocument("{qwerty : ytrewq}");
+        reader.read(null);
     }
 
     @Test
     public void testSimpleJsonDocument() throws Exception {
         final String document = "   { \"brand\" : \"Mercedes\", \"doors\" : 5 }";
+        reader.setDocument(document);
         JsonField field = AtlasJsonModelFactory.createJsonField();
         field.setPath("/brand");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Mercedes"));
 
         field.setPath("/doors");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is(5));
 
@@ -52,15 +56,16 @@ public class JsonFieldReaderTest {
     @Test
     public void testSimpleJsonDocumentWithRoot() throws Exception {
         final String document = " {\"car\" :{ \"brand\" : \"Mercedes\", \"doors\" : 5 } }";
+        reader.setDocument(document);
         JsonField field = AtlasJsonModelFactory.createJsonField();
         field.setPath("/car/doors");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is(5));
         resetField(field);
 
         field.setPath("/car/brand");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Mercedes"));
     }
@@ -72,45 +77,46 @@ public class JsonFieldReaderTest {
                 + "      {\"value\": \"New\", \"onclick\": \"CreateNewDoc()\"},\n"
                 + "      {\"value\": \"Open\", \"onclick\": \"OpenDoc()\"},\n"
                 + "      {\"value\": \"Close\", \"onclick\": \"CloseDoc()\"}\n" + "    ]\n" + "  }\n" + "}}";
+        reader.setDocument(document);
 
         JsonField field = AtlasJsonModelFactory.createJsonField();
         field.setPath("/menu/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("file"));
 
         field.setPath("/menu/value");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Filed"));
 
-        field.setPath("/menu/popup/menuitem/value");
-        reader.read(document, field);
+        field.setPath("/menu/popup/menuitem[0]/value");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("New"));
 
-        field.setPath("/menu/popup/menuitem/onclick");
-        reader.read(document, field);
+        field.setPath("/menu/popup/menuitem[0]/onclick");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("CreateNewDoc()"));
 
         field.setPath("/menu/popup/menuitem[1]/value");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Open"));
 
         field.setPath("/menu/popup/menuitem[1]/onclick");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("OpenDoc()"));
 
         field.setPath("/menu/popup/menuitem[2]/value");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Close"));
 
         field.setPath("/menu/popup/menuitem[2]/onclick");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("CloseDoc()"));
     }
@@ -119,555 +125,576 @@ public class JsonFieldReaderTest {
     public void testComplexJsonDocumentHighlyNested() throws Exception {
         final String document = new String(
                 Files.readAllBytes(Paths.get("src/test/resources/highly-nested-object.json")));
+        reader.setDocument(document);
+
         JsonField field = AtlasJsonModelFactory.createJsonField();
         field.setPath("/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("0001"));
         resetField(field);
 
         field.setPath("/type");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("donut"));
         resetField(field);
 
         field.setPath("/name");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Cake"));
         resetField(field);
 
         field.setPath("/ppu");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is(0.55));
         resetField(field);
 
-        field.setPath("/batters/batter/id");
-        reader.read(document, field);
+        field.setPath("/batters/batter[0]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("1001"));
         resetField(field);
 
-        field.setPath("/batters/batter/type");
-        reader.read(document, field);
+        field.setPath("/batters/batter[0]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Regular"));
         resetField(field);
 
         field.setPath("/batters/batter[1]/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("1002"));
         resetField(field);
 
         field.setPath("/batters/batter[1]/type");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Chocolate"));
         resetField(field);
 
         field.setPath("/batters/batter[2]/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("1003"));
         resetField(field);
 
         field.setPath("/batters/batter[2]/type");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Blueberry"));
         resetField(field);
 
         field.setPath("/batters/batter[3]/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("1004"));
         resetField(field);
 
         field.setPath("/batters/batter[3]/type");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Devil's Food"));
         resetField(field);
 
-        field.setPath("/topping/id");
-        reader.read(document, field);
+        field.setPath("/topping[0]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5001"));
         resetField(field);
 
-        field.setPath("/topping/type");
-        reader.read(document, field);
+        field.setPath("/topping[0]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("None"));
         resetField(field);
 
-        field.setPath("/topping/id[1]");
-        reader.read(document, field);
+        field.setPath("/topping[1]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5002"));
         resetField(field);
 
-        field.setPath("/topping/type[1]");
-        reader.read(document, field);
+        field.setPath("/topping[1]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Glazed"));
         resetField(field);
 
-        field.setPath("/topping/id[2]");
-        reader.read(document, field);
+        field.setPath("/topping[2]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5005"));
         resetField(field);
 
-        field.setPath("/topping/type[2]");
-        reader.read(document, field);
+        field.setPath("/topping[2]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Sugar"));
         resetField(field);
 
-        field.setPath("/topping/id[3]");
-        reader.read(document, field);
+        field.setPath("/topping[3]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5007"));
         resetField(field);
 
-        field.setPath("/topping/type[3]");
-        reader.read(document, field);
+        field.setPath("/topping[3]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Powdered Sugar"));
         resetField(field);
 
-        field.setPath("/topping/id[4]");
-        reader.read(document, field);
+        field.setPath("/topping[4]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5006"));
         resetField(field);
 
-        field.setPath("/topping/type[4]");
-        reader.read(document, field);
+        field.setPath("/topping[4]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Chocolate with Sprinkles"));
         resetField(field);
 
-        field.setPath("/topping/id[5]");
-        reader.read(document, field);
+        field.setPath("/topping[5]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5003"));
         resetField(field);
 
-        field.setPath("/topping/type[5]");
-        reader.read(document, field);
+        field.setPath("/topping[5]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Chocolate"));
         resetField(field);
 
-        field.setPath("/topping/id[6]");
-        reader.read(document, field);
+        field.setPath("/topping[6]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5004"));
         resetField(field);
 
-        field.setPath("/topping/type[6]");
-        reader.read(document, field);
+        field.setPath("/topping[6]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Maple"));
         resetField(field);
-    }
-
-    @Test
-    public void testCollectionCountHighlyNested() throws Exception {
-        final String document = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/highly-nested-object.json")));
-        JsonField field = AtlasJsonModelFactory.createJsonField();
-        Integer count = reader.getCollectionCount(document, field, "batter");
-        assertNotNull(count);
-        assertEquals(Integer.valueOf(4), count);
-    }
-
-    @Test
-    public void testCollectionCountHighlyNestedSegmentDoesNotExist() throws Exception {
-        final String document = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/highly-nested-object.json")));
-        JsonField field = AtlasJsonModelFactory.createJsonField();
-        Integer count = reader.getCollectionCount(document, field, "battery");
-        assertNull(count);
     }
 
     @Test
     public void testComplexJsonDocumentHighlyComplexNested() throws Exception {
         final String document = new String(
                 Files.readAllBytes(Paths.get("src/test/resources/highly-complex-nested-object.json")));
+        reader.setDocument(document);
         JsonField field = AtlasJsonModelFactory.createJsonField();
-        field.setPath("/items/item/id");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("0001"));
         resetField(field);
 
-        field.setPath("/items/item/type");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("donut"));
         resetField(field);
 
-        field.setPath("/items/item/name");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/name");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Cake"));
         resetField(field);
 
-        field.setPath("/items/item/ppu");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/ppu");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is(0.55));
         resetField(field);
 
         // array of objects
-        field.setPath("/items/item/batters/batter/id");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/batters/batter[0]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("1001"));
         resetField(field);
 
-        field.setPath("/items/item/batters/batter/type");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/batters/batter[0]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Regular"));
         resetField(field);
 
-        field.setPath("/items/item/batters/batter[1]/id");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/batters/batter[1]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("1002"));
         resetField(field);
 
-        field.setPath("/items/item/batters/batter[1]/type");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/batters/batter[1]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Chocolate"));
         resetField(field);
 
-        field.setPath("/items/item/batters/batter[2]/id");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/batters/batter[2]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("1003"));
         resetField(field);
 
-        field.setPath("/items/item/batters/batter[2]/type");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/batters/batter[2]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Blueberry"));
         resetField(field);
 
-        field.setPath("/items/item/batters/batter[3]/id");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/batters/batter[3]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("1004"));
         resetField(field);
 
-        field.setPath("/items/item/batters/batter[3]/type");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/batters/batter[3]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Devil's Food"));
         resetField(field);
 
         // simple array
-        field.setPath("/items/item/topping/id");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[0]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5001"));
         resetField(field);
 
-        field.setPath("/items/item/topping/type");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[0]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("None"));
         resetField(field);
 
-        field.setPath("/items/item/topping/id[1]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[1]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5002"));
         resetField(field);
 
-        field.setPath("/items/item/topping/type[1]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[1]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Glazed"));
         resetField(field);
 
-        field.setPath("/items/item/topping/id[2]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[2]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5005"));
         resetField(field);
 
-        field.setPath("/items/item/topping/type[2]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[2]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Sugar"));
         resetField(field);
 
-        field.setPath("/items/item/topping/id[3]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[3]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5007"));
         resetField(field);
 
-        field.setPath("/items/item/topping/type[3]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[3]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Powdered Sugar"));
         resetField(field);
 
-        field.setPath("/items/item/topping/id[4]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[4]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5006"));
         resetField(field);
 
-        field.setPath("/items/item/topping/type[4]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[4]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Chocolate with Sprinkles"));
         resetField(field);
 
-        field.setPath("/items/item/topping/id[5]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[5]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5003"));
         resetField(field);
 
-        field.setPath("/items/item/topping/type[5]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[5]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Chocolate"));
         resetField(field);
 
-        field.setPath("/items/item/topping/id[6]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[6]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5004"));
         resetField(field);
 
-        field.setPath("/items/item/topping/type[6]");
-        reader.read(document, field);
+        field.setPath("/items/item[0]/topping[6]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Maple"));
         resetField(field);
 
         field.setPath("/items/item[1]/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("0002"));
         resetField(field);
 
         field.setPath("/items/item[1]/type");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("donut"));
         resetField(field);
 
         field.setPath("/items/item[1]/name");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Raised"));
         resetField(field);
 
         field.setPath("/items/item[1]/ppu");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is(0.55));
         resetField(field);
 
         // array of objects
-        field.setPath("/items/item[1]/batters/batter/id");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/batters/batter[0]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("1001"));
         resetField(field);
 
-        field.setPath("/items/item[1]/batters/batter/type");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/batters/batter[0]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Regular"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/id");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[0]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5001"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/type");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[0]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("None"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/id[1]");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[1]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5002"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/type[1]");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[1]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Glazed"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/id[2]");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[2]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5005"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/type[2]");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[2]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Sugar"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/id[3]");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[3]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5003"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/type[3]");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[3]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Chocolate"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/id[4]");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[4]/id");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("5004"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/type[4]");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[4]/type");
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Maple"));
         resetField(field);
 
-        field.setPath("/items/item[1]/topping/id[5]");
-        reader.read(document, field);
+        field.setPath("/items/item[1]/topping[5]/id");
+        reader.read(field);
         assertNull(field.getValue());
         resetField(field);
 
         field.setPath("/items/item[2]/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("0003"));
         resetField(field);
 
         field.setPath("/items/item[2]/type");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("donut"));
         resetField(field);
 
         field.setPath("/items/item[2]/name");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Old Fashioned"));
         resetField(field);
 
         field.setPath("/items/item[2]/ppu");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is(0.55));
         resetField(field);
 
         field.setPath("/items/item[3]/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("0004"));
         resetField(field);
 
         field.setPath("/items/item[3]/type");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("bar"));
         resetField(field);
 
         field.setPath("/items/item[3]/name");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Bar"));
         resetField(field);
 
         field.setPath("/items/item[3]/ppu");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is(0.75));
         resetField(field);
 
         field.setPath("/items/item[4]/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("0005"));
         resetField(field);
 
         field.setPath("/items/item[4]/type");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("twist"));
         resetField(field);
 
         field.setPath("/items/item[4]/name");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Twist"));
         resetField(field);
 
         field.setPath("/items/item[4]/ppu");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is(0.65));
         resetField(field);
 
         field.setPath("/items/item[5]/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("0006"));
         resetField(field);
 
         field.setPath("/items/item[5]/type");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("filled"));
         resetField(field);
 
         field.setPath("/items/item[5]/name");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("Filled"));
         resetField(field);
 
         field.setPath("/items/item[5]/ppu");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is(0.75));
         resetField(field);
 
         field.setPath("/items/item[5]/fillings/filling[2]/id");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is("7004"));
         resetField(field);
 
         field.setPath("/items/item[5]/fillings/filling[3]/addcost");
-        reader.read(document, field);
+        reader.read(field);
         assertNotNull(field.getValue());
         assertThat(field.getValue(), Is.is(0));
         resetField(field);
+    }
+
+    @Test
+    public void testSameFieldNameInDifferentPath() throws Exception {
+        final String document = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/same-field-name-in-different-path.json")));
+        reader.setDocument(document);
+        JsonField field = AtlasJsonModelFactory.createJsonField();
+        field.setPath("/name");
+        reader.read(field);
+        assertEquals("name", field.getValue());
+        field.setPath("/object1/name");
+        reader.read(field);
+        assertEquals("object1-name", field.getValue());
+        field.setPath("/object2/name");
+        reader.read(field);
+        assertEquals("object2-name", field.getValue());
+        field.setPath("/object1/object2/name");
+        reader.read(field);
+        assertEquals("object1-object2-name", field.getValue());
+    }
+
+    @Test
+    public void testArrayUnderRoot() throws Exception {
+        final String document = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/array-under-root.json")));
+        reader.setDocument(document);
+        JsonField field = AtlasJsonModelFactory.createJsonField();
+        field.setPath("/array[0]");
+        reader.read(field);
+        assertEquals("array-zero", field.getValue());
+        field.setPath("/array[1]");
+        reader.read(field);
+        assertEquals("array-one", field.getValue());
+        field.setPath("/array[2]");
+        reader.read(field);
+        assertEquals("array-two", field.getValue());
     }
 
     private void resetField(JsonField field) {

--- a/atlas-json-parent/atlas-json-core/src/test/resources/array-under-root.json
+++ b/atlas-json-parent/atlas-json-core/src/test/resources/array-under-root.json
@@ -1,0 +1,7 @@
+{
+    "array": [
+        "array-zero",
+        "array-one",
+        "array-two"
+    ]
+}

--- a/atlas-json-parent/atlas-json-core/src/test/resources/same-field-name-in-different-path.json
+++ b/atlas-json-parent/atlas-json-core/src/test/resources/same-field-name-in-different-path.json
@@ -1,0 +1,12 @@
+{
+    "object1": {
+        "object2": {
+            "name": "object1-object2-name"
+        },
+        "name": "object1-name"
+    },
+    "name": "name",
+    "object2": {
+        "name": "object2-name"
+    }
+}


### PR DESCRIPTION
…) to avoid jumping to the deeper node

Fixes: #262

fix(atlas-json): JsonFieldReader: top level array field is not recognized
Fixes: #263

Also a bit improved to cache JsonFieldReader/JsonNode toward #50